### PR TITLE
Require NeoZed agent workflow context

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f graphify-out/graph.json ] && echo '{\"systemMessage\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}' || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ DerivedData/
 Packages
 xcuserdata/
 crates/docs_preprocessor/actions.json
+graphify-out
 
 # Don't commit any secrets to the repo.
 .env

--- a/.rules
+++ b/.rules
@@ -188,3 +188,13 @@ Rules emerge from validated patterns, not one-off observations. The workflow is:
 1. Agent notes a pattern during a session.
 2. Team validates the pattern in code review.
 3. A dedicated commit adds the rule with context on *why* it exists.
+
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/.rules
+++ b/.rules
@@ -137,6 +137,31 @@ Other entities can then register a callback to handle these events by doing `cx.
 
 - Use `./script/clippy` instead of `cargo clippy`
 
+# NeoZed maintenance workflow
+
+Before making product, feature, bug, upstream, release, or branching decisions in this fork, agents must read:
+
+- `docs/neozed/README.md`
+- `docs/neozed/WORKFLOW.md`
+
+For feature or bug work, agents must also read `docs/neozed/FEATURE_LEDGER.md` before implementation and update it when the feature state changes.
+
+For upstream port, upstream release, stable backport, or branch-management work, agents must also read:
+
+- `docs/neozed/FORK_POLICY.md`
+- `docs/neozed/UPSTREAM_BASE.md`
+- `docs/neozed/UPSTREAM_REVIEW.md`
+
+Default branch policy:
+
+- `main` is the NeoZed development branch.
+- `stable/v1.0` is the stable release branch.
+- New features target `main`.
+- `stable/v1.0` receives only reviewed release/backport changes that satisfy the stable policy.
+- Do not merge upstream branches directly into NeoZed branches.
+
+Before opening or updating a PR, agents must include the commands they ran, verification evidence, and any screenshot or recording proof requested by the issue. Use `docs/neozed/AGENT_RUN_LOG_TEMPLATE.md` as the checklist.
+
 # Pull request hygiene
 
 When an agent opens or updates a pull request, it must:


### PR DESCRIPTION
## Summary

- Add graphify agent guidance and Codex hook metadata.
- Require agents to read NeoZed workflow docs before feature, bug, upstream, release, or branching work.
- Document the stable/dev branch policy in the automatically loaded agent rules.

## Verification

- Ran `git diff --check` before committing.
- Commit hooks ran graphify rebuild attempts; graphify refused to overwrite the existing graph because of the existing one-node mismatch.

Release Notes:

- N/A