### PR TITLE
Document installed app screenshot proof workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/20_neozed_feature.yml
+++ b/.github/ISSUE_TEMPLATE/20_neozed_feature.yml
@@ -72,7 +72,7 @@ body:
       description: Build, test, screenshot, or recording evidence required in the PR.
       value: |
         - Build/test: run `cargo fmt --all -- --check`; run `cargo check --workspace --all-targets` and fix every warning and error before committing; run focused clippy/tests for changed crates.
-        - Screenshot:
+        - Screenshot: for UI proof, run `script/bundle-mac -d -i -o` from the repo root to build, install, and open `/Applications/Neo Zed.app`; then use the Computer Use plugin to interact with that installed app window and capture window screenshots. Attach screenshots to the PR conversation. Never commit screenshots to the repo.
         - Screen recording:
         - Manual verification:
         - Commit discipline: keep commits atomic. If `cargo check --workspace --all-targets` reveals pre-existing or cleanup-only warnings/errors, fix and commit those separately before committing the feature changes. Do not combine warning/error cleanup with the feature implementation commit unless the warning/error is directly caused by that implementation.

--- a/.github/ISSUE_TEMPLATE/21_neozed_bug.yml
+++ b/.github/ISSUE_TEMPLATE/21_neozed_bug.yml
@@ -44,7 +44,7 @@ body:
       label: Required proof
       value: |
         - Build/test:
-        - Screenshot:
+        - Screenshot: for UI proof, run `script/bundle-mac -d -i -o` from the repo root to build, install, and open `/Applications/Neo Zed.app`; then use the Computer Use plugin to interact with that installed app window and capture window screenshots. Attach screenshots to the PR conversation. Never commit screenshots to the repo.
         - Screen recording:
         - Manual verification:
     validations:


### PR DESCRIPTION
## Summary

- Update NeoZed feature and bug issue templates to document the installed-app screenshot proof workflow.
- Document `script/bundle-mac -d -i -o` as the build, install, and open path for `/Applications/Neo Zed.app` before using the Computer Use plugin.
- Clarify that screenshots belong on the PR conversation and must never be committed to the repository.

## Verification

- Passed: YAML parse check for `.github/ISSUE_TEMPLATE/20_neozed_feature.yml` and `.github/ISSUE_TEMPLATE/21_neozed_bug.yml`.
- Passed: `TERM= script/bundle-mac -d -i -o` built, signed, installed, and opened `/Applications/Neo Zed.app`.
- Passed: used the Computer Use plugin against the installed NeoZed app window and captured a window-region screenshot.
- Passed: branch diff now contains only the two issue-template files.

Release Notes:

- N/A