### PR TITLE
Update stable to Zed v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22202,7 +22202,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -84,6 +84,7 @@ pub struct StreamingEditFileToolInput {
     /// - 'edit': Make granular edits to an existing file. Requires 'edits' field.
     ///
     /// When a file already exists or you just created it, prefer editing it as opposed to recreating it from scratch.
+    #[serde(deserialize_with = "deserialize_maybe_stringified")]
     pub mode: StreamingEditFileMode,
 
     /// The complete content for the new file (required for 'write' mode).
@@ -96,7 +97,7 @@ pub struct StreamingEditFileToolInput {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_optional_vec_or_json_string"
+        deserialize_with = "deserialize_maybe_stringified"
     )]
     pub edits: Option<Vec<Edit>>,
 }
@@ -133,11 +134,11 @@ struct StreamingEditFileToolPartialInput {
     display_description: Option<String>,
     #[serde(default)]
     path: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_maybe_stringified")]
     mode: Option<StreamingEditFileMode>,
     #[serde(default)]
     content: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_optional_vec_or_json_string")]
+    #[serde(default, deserialize_with = "deserialize_maybe_stringified")]
     edits: Option<Vec<PartialEdit>>,
 }
 
@@ -149,30 +150,23 @@ pub struct PartialEdit {
     pub new_text: Option<String>,
 }
 
-/// Sometimes the model responds with a stringified JSON array of edits (`"[...]"`) instead of a regular array (`[...]`)
-fn deserialize_optional_vec_or_json_string<'de, T, D>(
-    deserializer: D,
-) -> Result<Option<Vec<T>>, D::Error>
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ValueOrJsonString<T> {
+    Value(T),
+    String(String),
+}
+
+fn deserialize_maybe_stringified<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: DeserializeOwned,
     D: Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum VecOrJsonString<T> {
-        Vec(Vec<T>),
-        String(String),
-    }
-
-    let value = Option::<VecOrJsonString<T>>::deserialize(deserializer)?;
-    match value {
-        None => Ok(None),
-        Some(VecOrJsonString::Vec(items)) => Ok(Some(items)),
-        Some(VecOrJsonString::String(string)) => serde_json::from_str::<Vec<T>>(&string)
-            .map(Some)
-            .map_err(|error| {
-                D::Error::custom(format!("failed to parse stringified edits array: {error}"))
-            }),
+    match ValueOrJsonString::<T>::deserialize(deserializer)? {
+        ValueOrJsonString::Value(value) => Ok(value),
+        ValueOrJsonString::String(string) => serde_json::from_str::<T>(&string).map_err(|error| {
+            D::Error::custom(format!("failed to parse stringified value: {error}"))
+        }),
     }
 }
 
@@ -4178,6 +4172,72 @@ mod tests {
             !fs.is_file(path!("/root/dir/new_file.txt").as_ref()).await,
             "file should be deleted after rejecting creation, but an empty file was left behind"
         );
+    }
+
+    #[test]
+    fn test_input_deserializes_double_encoded_fields() {
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": "[{\"old_text\": \"hello\\nworld\", \"new_text\": \"HELLO\\nWORLD\"}]"
+        }))
+        .expect("input should deserialize");
+
+        assert!(matches!(input.mode, StreamingEditFileMode::Edit));
+        let edits = input.edits.expect("edits should deserialize");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].old_text, "hello\nworld");
+        assert_eq!(edits[0].new_text, "HELLO\nWORLD");
+
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\""
+        }))
+        .expect("input should deserialize");
+        assert!(input.edits.is_none());
+
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": null
+        }))
+        .expect("input should deserialize");
+        assert!(input.edits.is_none());
+
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": "[{\"old_text\": \"hello\\nworld\", \"new_text\": \"HELLO\\nWORLD\"}]"
+        }))
+        .expect("input should deserialize");
+
+        assert!(matches!(input.mode, Some(StreamingEditFileMode::Edit)));
+        let edits = input.edits.expect("edits should deserialize");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].old_text.as_deref(), Some("hello\nworld"));
+        assert_eq!(edits[0].new_text.as_deref(), Some("HELLO\nWORLD"));
+
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt"
+        }))
+        .expect("input should deserialize");
+        assert!(input.mode.is_none());
+        assert!(input.edits.is_none());
+
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": null,
+            "edits": null
+        }))
+        .expect("input should deserialize");
+        assert!(input.mode.is_none());
+        assert!(input.edits.is_none());
     }
 
     async fn setup_test_with_fs(

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.0.0"
+version = "1.0.1"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]


### PR DESCRIPTION
## Summary

- Cherry-picked upstream Zed v1.0.1 commits `eaac76222a` and `ad3e097279` onto `stable/v1.0`.
- Added support for double-encoded/stringified edit-tool `mode` and `edits` inputs.
- Bumped the Zed crate version from `1.0.0` to `1.0.1` in `crates/zed/Cargo.toml` and `Cargo.lock`.

## Validation

- `git diff --check origin/stable/v1.0...HEAD`
- `cargo test -p agent test_input_deserializes_double_encoded_fields` was attempted on the main PR branch but did not complete because this machine is missing Apple's Metal toolchain: `xcodebuild -downloadComponent MetalToolchain` is required for `gpui_macos` shader compilation.

Refs #12

Release Notes:

- Fixed an issue where agent failed to apply edits in some cases