### PR TITLE
Require checks before upstream PRs

### DIFF
--- a/crates/collab/tests/integration/git_tests.rs
+++ b/crates/collab/tests/integration/git_tests.rs
@@ -154,29 +154,6 @@ async fn load_commit_data_batch(
     commit_data
 }
 
-fn branch_list_snapshot(
-    project: &gpui::Entity<project::Project>,
-    cx: &mut TestAppContext,
-) -> (Option<String>, Vec<String>) {
-    project.read_with(cx, |project, cx| {
-        let repos = project.repositories(cx);
-        assert_eq!(repos.len(), 1, "project should have exactly 1 repository");
-        let repo = repos.values().next().unwrap();
-        let snapshot = repo.read(cx).snapshot();
-        (
-            snapshot
-                .branch
-                .as_ref()
-                .map(|branch| branch.name().to_string()),
-            snapshot
-                .branch_list
-                .iter()
-                .map(|branch| branch.ref_name.to_string())
-                .collect(),
-        )
-    })
-}
-
 fn assert_remote_cache_matches_local_cache(
     local_repository: &gpui::Entity<Repository>,
     remote_repository: &gpui::Entity<Repository>,
@@ -805,95 +782,6 @@ async fn test_remote_git_commit_data_batches(
     assert_eq!(remote_batch_two.len(), 3);
 
     assert_remote_cache_matches_local_cache(&repo_a, &repo_b, cx_a, cx_b);
-}
-
-#[gpui::test]
-async fn test_branch_list_sync(
-    executor: BackgroundExecutor,
-    cx_a: &mut TestAppContext,
-    cx_b: &mut TestAppContext,
-) {
-    let mut server = TestServer::start(executor.clone()).await;
-    let client_a = server.create_client(cx_a, "user_a").await;
-    let client_b = server.create_client(cx_b, "user_b").await;
-    server
-        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b)])
-        .await;
-    let active_call_a = cx_a.read(ActiveCall::global);
-
-    client_a
-        .fs()
-        .insert_tree(
-            path!("/project"),
-            json!({ ".git": {}, "file.txt": "content" }),
-        )
-        .await;
-    client_a.fs().insert_branches(
-        Path::new(path!("/project/.git")),
-        &["main", "feature-1", "feature-2"],
-    );
-
-    let (project_a, _) = client_a.build_local_project(path!("/project"), cx_a).await;
-    executor.run_until_parked();
-
-    let host_snapshot = branch_list_snapshot(&project_a, cx_a);
-    assert_eq!(host_snapshot.0.as_deref(), Some("main"));
-    assert_eq!(
-        host_snapshot.1,
-        vec![
-            "refs/heads/feature-1".to_string(),
-            "refs/heads/feature-2".to_string(),
-            "refs/heads/main".to_string(),
-        ]
-    );
-
-    let project_id = active_call_a
-        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
-        .await
-        .unwrap();
-    let project_b = client_b.join_remote_project(project_id, cx_b).await;
-
-    executor.run_until_parked();
-
-    let repo_b = cx_b.update(|cx| project_b.read(cx).active_repository(cx).unwrap());
-
-    cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.create_branch("totally-new-branch".to_string(), None)
-        })
-    })
-    .await
-    .unwrap()
-    .unwrap();
-
-    cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch("totally-new-branch".to_string())
-        })
-    })
-    .await
-    .unwrap()
-    .unwrap();
-
-    executor.run_until_parked();
-
-    let host_snapshot_after_update = branch_list_snapshot(&project_a, cx_a);
-    assert_eq!(
-        host_snapshot_after_update.0.as_deref(),
-        Some("totally-new-branch")
-    );
-    assert_eq!(
-        host_snapshot_after_update.1,
-        vec![
-            "refs/heads/feature-1".to_string(),
-            "refs/heads/feature-2".to_string(),
-            "refs/heads/main".to_string(),
-            "refs/heads/totally-new-branch".to_string(),
-        ]
-    );
-
-    let guest_snapshot_after_update = branch_list_snapshot(&project_b, cx_b);
-    assert_eq!(guest_snapshot_after_update, host_snapshot_after_update);
 }
 
 #[gpui::test]

--- a/script/neozed/check-upstream-release
+++ b/script/neozed/check-upstream-release
@@ -152,6 +152,7 @@ $candidate_commits
 - [ ] All commits applied to \`${new_stable_branch}\`
 - [ ] All commits applied to \`main\`
 - [ ] Conflicts on \`main\` resolved, NeoZed customizations preserved
+- [ ] \`cargo check --workspace --all-targets\` passes before any PR is opened
 - [ ] \`script/neozed/upstream-reviewed-tag\` updated to \`$latest_stable_tag\` and merged
 - [ ] (Minor only) \`${old_stable_branch}\` deleted
 EOF
@@ -199,8 +200,9 @@ if [[ "$upgrade_type" == "patch" ]]; then
 
 1. **Cherry-pick all commits** from \`${LAST_REVIEWED_UPSTREAM_TAG}\` to \`${latest_stable_tag}\` onto \`${new_stable_branch}\` in a PR titled \`Sync upstream Zed ${latest_stable_tag} to ${new_stable_branch}\`. Take all commits — they are already upstream-vetted stable commits. Leave commit messages unchanged.
 2. **Cherry-pick the same commits onto \`main\`** in a separate PR titled \`Merge upstream Zed ${latest_stable_tag}\`. Resolve any conflicts in favor of keeping NeoZed customizations while taking upstream functional changes.
-3. **Update baseline** — include a one-line change to \`script/neozed/upstream-reviewed-tag\` setting its content to \`${latest_stable_tag}\` in the \`main\` PR.
-4. **Close this issue** once both PRs are merged.
+3. **Run verification before opening PRs** — run \`cargo check --workspace --all-targets\` before raising each PR.
+4. **Update baseline** — include a one-line change to \`script/neozed/upstream-reviewed-tag\` setting its content to \`${latest_stable_tag}\` in the \`main\` PR.
+5. **Close this issue** once both PRs are merged.
 EOF
 else
     cat > "$comment_file" <<EOF
@@ -224,11 +226,13 @@ else
 
 2. **Cherry-pick all commits** from \`${LAST_REVIEWED_UPSTREAM_TAG}\` to \`${latest_stable_tag}\` onto \`main\` in a PR titled \`Merge upstream Zed ${latest_stable_tag}\`. Same process as a patch cherry-pick but over a larger range. Take all commits. Resolve any conflicts in favor of keeping NeoZed customizations (identity, branding, \`assets/settings/default.json\`, \`script/neozed/\`) while taking upstream functional changes.
 
-3. **Update baseline** — include a one-line change to \`script/neozed/upstream-reviewed-tag\` setting its content to \`${latest_stable_tag}\` in the \`main\` PR.
+3. **Run verification before opening the PR** — run \`cargo check --workspace --all-targets\` before raising the \`main\` PR.
 
-4. **Delete \`${old_stable_branch}\`** — upstream never patches an old minor once a new one ships, so this branch is a permanent dead end. Run: \`git push origin --delete ${old_stable_branch}\`
+4. **Update baseline** — include a one-line change to \`script/neozed/upstream-reviewed-tag\` setting its content to \`${latest_stable_tag}\` in the \`main\` PR.
 
-5. **Close this issue** once the \`main\` PR is merged.
+5. **Delete \`${old_stable_branch}\`** — upstream never patches an old minor once a new one ships, so this branch is a permanent dead end. Run: \`git push origin --delete ${old_stable_branch}\`
+
+6. **Close this issue** once the \`main\` PR is merged.
 
 If the conflict surface is too large to resolve in one pass, open a draft PR and leave a comment describing the blockers.
 EOF


### PR DESCRIPTION
## Summary

- Remove duplicate collab git test definitions that were left in the merged upstream update
- Update the upstream release watcher instructions to require `cargo check --workspace --all-targets` before opening upstream PRs
- Confirm PR #19 was reported by GitHub as manually merged by `Nkr1shna`, with no auto-merge request recorded

## Verification

- `bash -n script/neozed/check-upstream-release`
- `git diff --check`
- `rg -n 'fn branch_list_snapshot|async fn test_branch_list_sync|async fn test_remote_git_commit_data_batches|<<<<<<<|>>>>>>>' crates/collab/tests/integration/git_tests.rs script/neozed/check-upstream-release`
- `cargo check --workspace --all-targets`

Release Notes:

- N/A