### PR TITLE
Update stable v1.2 to upstream Zed v1.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22410,7 +22410,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,7 +3580,6 @@ dependencies = [
  "http_client",
  "log",
  "net",
- "oauth_callback_server",
  "parking_lot",
  "pollster 0.4.0",
  "postage",
@@ -3592,6 +3591,7 @@ dependencies = [
  "sha2",
  "slotmap",
  "tempfile",
+ "tiny_http",
  "url",
  "util",
 ]
@@ -9675,26 +9675,20 @@ dependencies = [
  "log",
  "menu",
  "mistral",
- "oauth_callback_server",
  "ollama",
  "open_ai",
  "open_router",
  "opencode",
- "parking_lot",
  "pretty_assertions",
- "rand 0.9.4",
  "release_channel",
  "schemars 1.0.4",
  "serde",
  "serde_json",
  "settings",
- "sha2",
- "smol",
  "strum 0.27.2",
  "tokio",
  "ui",
  "ui_input",
- "url",
  "util",
  "x_ai",
 ]
@@ -11504,17 +11498,6 @@ dependencies = [
  "rmpv",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "oauth_callback_server"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures 0.3.32",
- "log",
- "tiny_http",
- "url",
 ]
 
 [[package]]
@@ -22410,7 +22393,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,6 +3580,7 @@ dependencies = [
  "http_client",
  "log",
  "net",
+ "oauth_callback_server",
  "parking_lot",
  "pollster 0.4.0",
  "postage",
@@ -3591,7 +3592,6 @@ dependencies = [
  "sha2",
  "slotmap",
  "tempfile",
- "tiny_http",
  "url",
  "util",
 ]
@@ -9675,20 +9675,26 @@ dependencies = [
  "log",
  "menu",
  "mistral",
+ "oauth_callback_server",
  "ollama",
  "open_ai",
  "open_router",
  "opencode",
+ "parking_lot",
  "pretty_assertions",
+ "rand 0.9.4",
  "release_channel",
  "schemars 1.0.4",
  "serde",
  "serde_json",
  "settings",
+ "sha2",
+ "smol",
  "strum 0.27.2",
  "tokio",
  "ui",
  "ui_input",
+ "url",
  "util",
  "x_ai",
 ]
@@ -11498,6 +11504,17 @@ dependencies = [
  "rmpv",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "oauth_callback_server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures 0.3.32",
+ "log",
+ "tiny_http",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22410,7 +22410,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ members = [
     "crates/net",
     "crates/node_runtime",
     "crates/notifications",
+    "crates/oauth_callback_server",
     "crates/ollama",
     "crates/onboarding",
     "crates/opencode",
@@ -397,6 +398,7 @@ nc = { path = "crates/nc" }
 net = { path = "crates/net" }
 node_runtime = { path = "crates/node_runtime" }
 notifications = { path = "crates/notifications" }
+oauth_callback_server = { path = "crates/oauth_callback_server" }
 ollama = { path = "crates/ollama" }
 onboarding = { path = "crates/onboarding" }
 opencode = { path = "crates/opencode" }

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3123,6 +3123,57 @@ async fn test_truncate_first_message(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_latest_token_usage_counts_cached_input_tokens(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let message_1_id = UserMessageId::new();
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(message_1_id, ["Message 1"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_text_chunk("Response 1");
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::UsageUpdate(
+        language_model::TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 25,
+            cache_read_input_tokens: 75,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    thread.read_with(cx, |thread, _| {
+        assert_eq!(
+            thread.latest_token_usage(),
+            Some(acp_thread::TokenUsage {
+                used_tokens: 250,
+                max_tokens: 1_000_000,
+                max_output_tokens: None,
+                input_tokens: 200,
+                output_tokens: 50,
+            })
+        );
+    });
+
+    let message_2_id = UserMessageId::new();
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(message_2_id.clone(), ["Message 2"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    thread.read_with(cx, |thread, _| {
+        assert_eq!(thread.tokens_before_message(&message_2_id), Some(200));
+    });
+}
+
+#[gpui::test]
 async fn test_truncate_second_message(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1702,11 +1702,13 @@ impl Thread {
     pub fn latest_token_usage(&self) -> Option<acp_thread::TokenUsage> {
         let usage = self.latest_request_token_usage()?;
         let model = self.model.clone()?;
+        let input_tokens = total_input_tokens(usage);
+
         Some(acp_thread::TokenUsage {
             max_tokens: model.max_token_count(),
             max_output_tokens: model.max_output_tokens(),
             used_tokens: usage.total_tokens(),
-            input_tokens: usage.input_tokens,
+            input_tokens,
             output_tokens: usage.output_tokens,
         })
     }
@@ -1725,7 +1727,7 @@ impl Thread {
                 if &user_msg.id == target_id {
                     let prev_id = previous_user_message_id?;
                     let usage = self.request_token_usage.get(prev_id)?;
-                    return Some(usage.input_tokens);
+                    return Some(total_input_tokens(*usage));
                 }
                 previous_user_message_id = Some(&user_msg.id);
             }
@@ -3168,6 +3170,13 @@ impl Thread {
             }),
         }
     }
+}
+
+fn total_input_tokens(usage: language_model::TokenUsage) -> u64 {
+    usage
+        .input_tokens
+        .saturating_add(usage.cache_creation_input_tokens)
+        .saturating_add(usage.cache_read_input_tokens)
 }
 
 struct RunningTurn {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1214,7 +1214,15 @@ impl AgentPanel {
         let draft = self.ensure_draft(source, window, cx);
         if let BaseView::AgentThread { conversation_view } = &self.base_view {
             if conversation_view.entity_id() == draft.entity_id() {
-                if focus {
+                // If we're already viewing the draft as the base view but an
+                // overlay (e.g. Settings) is covering it, clear the overlay
+                // so the user actually sees the draft they asked for.
+                // Otherwise pressing "New Thread" from the Settings panel is
+                // a silent no-op because the early return below would leave
+                // the overlay on top of the draft.
+                if self.overlay_view.is_some() {
+                    self.clear_overlay(focus, window, cx);
+                } else if focus {
                     self.focus_handle(cx).focus(window, cx);
                 }
                 return;
@@ -4719,6 +4727,7 @@ mod tests {
         });
 
         let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
         let project = Project::test(fs.clone(), [], cx).await;
 
         let multi_workspace =
@@ -4735,6 +4744,63 @@ mod tests {
         });
 
         (panel, cx)
+    }
+
+    #[gpui::test]
+    async fn test_new_thread_dismisses_settings_overlay(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+
+        // Put the panel on its ephemeral new-draft view so the base view
+        // already contains the draft that `NewThread` would activate.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.activate_draft(true, "agent_panel", window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, cx| {
+            assert!(
+                panel.active_thread_is_draft(cx),
+                "precondition: base view should be the ephemeral draft"
+            );
+            assert!(!panel.is_overlay_open());
+        });
+
+        // Simulate the Settings overlay being open on top of the draft.
+        // We don't go through `open_configuration` here because it would
+        // build provider configuration views, which call into
+        // `LanguageModelProvider::configuration_view` — unimplemented for
+        // the fake provider used in tests. The bug being exercised lives
+        // entirely in the overlay/base-view bookkeeping, so toggling the
+        // overlay flag directly is sufficient.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.set_overlay(OverlayView::Configuration, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, _cx| {
+            assert!(
+                panel.is_overlay_open(),
+                "precondition: Settings overlay should be open"
+            );
+        });
+
+        // Dispatching `NewThread` while Settings is open must dismiss the
+        // overlay so the user actually sees the new thread. Previously
+        // this was a silent no-op: `activate_draft` early-returned without
+        // clearing the overlay because the base view already held the
+        // draft.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.new_thread(&NewThread, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, cx| {
+            assert!(
+                !panel.is_overlay_open(),
+                "Settings overlay should be dismissed when invoking NewThread"
+            );
+            assert!(panel.active_thread_is_draft(cx));
+        });
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3213,6 +3213,7 @@ impl ThreadView {
             .child(
                 v_flex()
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
+                    .when(max_content_width.is_none(), |this| this.w_full())
                     .when(fills_container, |this| this.h_full())
                     .flex_shrink()
                     .flex_grow_0()

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1396,7 +1396,7 @@ impl Client {
                     // any other app running on the user's device.
                     let (public_key, private_key) =
                         rpc::auth::keypair().context("failed to generate keypair for auth")?;
-                    let public_key_string = String::try_from(public_key)
+                    let public_key = String::try_from(public_key)
                         .context("failed to serialize public key for auth")?;
 
                     if let Some((login, token)) =
@@ -1420,11 +1420,22 @@ impl Client {
                         .context("server not bound to a TCP address")?
                         .port();
 
+                    #[derive(Serialize)]
+                    struct NativeAppSignInQueryParams {
+                        native_app_port: u16,
+                        native_app_public_key: String,
+                        system_id: Option<Arc<str>>,
+                    }
+
                     // Open the Zed sign-in page in the user's browser, with query parameters that indicate
                     // that the user is signing in from a Zed app running on the same device.
                     let url = http.build_url(&format!(
-                        "/native_app_signin?native_app_port={}&native_app_public_key={}",
-                        port, public_key_string
+                        "/native_app_signin?{}",
+                        serde_urlencoded::to_string(&NativeAppSignInQueryParams {
+                            native_app_port: port,
+                            native_app_public_key: public_key,
+                            system_id: this.telemetry.system_id(),
+                        })?
                     ));
 
                     open_url_tx.send(url).log_err();

--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -26,6 +26,7 @@ gpui.workspace = true
 http_client = { workspace = true, features = ["test-support"] }
 log.workspace = true
 net.workspace = true
+oauth_callback_server.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
 postage.workspace = true
@@ -36,7 +37,6 @@ settings.workspace = true
 sha2.workspace = true
 slotmap.workspace = true
 tempfile.workspace = true
-tiny_http.workspace = true
 url = { workspace = true, features = ["serde"] }
 util.workspace = true
 

--- a/crates/context_server/src/oauth.rs
+++ b/crates/context_server/src/oauth.rs
@@ -20,18 +20,18 @@ use anyhow::{Context as _, Result, anyhow, bail};
 use async_trait::async_trait;
 use base64::Engine as _;
 use futures::AsyncReadExt as _;
+use futures::FutureExt as _;
 use futures::channel::mpsc;
+use futures::future::BoxFuture;
 use http_client::{AsyncBody, HttpClient, Request};
 use parking_lot::Mutex as SyncMutex;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use url::Url;
-use util::ResultExt as _;
 
 /// The CIMD URL where Zed's OAuth client metadata document is hosted.
 pub const CIMD_URL: &str = "https://zed.dev/oauth/client-metadata.json";
@@ -992,57 +992,13 @@ impl OAuthCallback {
     /// Parse the query string from a callback URL like
     /// `http://127.0.0.1:<port>/callback?code=...&state=...`.
     pub fn parse_query(query: &str) -> Result<Self> {
-        let mut code: Option<String> = None;
-        let mut state: Option<String> = None;
-        let mut error: Option<String> = None;
-        let mut error_description: Option<String> = None;
-
-        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
-            match key.as_ref() {
-                "code" => {
-                    if !value.is_empty() {
-                        code = Some(value.into_owned());
-                    }
-                }
-                "state" => {
-                    if !value.is_empty() {
-                        state = Some(value.into_owned());
-                    }
-                }
-                "error" => {
-                    if !value.is_empty() {
-                        error = Some(value.into_owned());
-                    }
-                }
-                "error_description" => {
-                    if !value.is_empty() {
-                        error_description = Some(value.into_owned());
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // Check for OAuth error response (RFC 6749 Section 4.1.2.1) before
-        // checking for missing code/state.
-        if let Some(error_code) = error {
-            bail!(
-                "OAuth authorization failed: {} ({})",
-                error_code,
-                error_description.as_deref().unwrap_or("no description")
-            );
-        }
-
-        let code = code.ok_or_else(|| anyhow!("missing 'code' parameter in OAuth callback"))?;
-        let state = state.ok_or_else(|| anyhow!("missing 'state' parameter in OAuth callback"))?;
-
-        Ok(Self { code, state })
+        let params = oauth_callback_server::OAuthCallbackParams::parse_query(query)?;
+        Ok(Self {
+            code: params.code,
+            state: params.state,
+        })
     }
 }
-
-/// How long to wait for the browser to complete the OAuth flow before giving
-/// up and releasing the loopback port.
-const CALLBACK_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 /// Start a loopback HTTP server to receive the OAuth authorization callback.
 ///
@@ -1056,104 +1012,24 @@ const CALLBACK_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 /// contains `code` and `state` query parameters, responds with a minimal
 /// HTML page telling the user they can close the tab, and shuts down.
 ///
-/// The callback server shuts down when the returned oneshot receiver is dropped
-/// (e.g. because the authentication task was cancelled), or after a timeout
-/// ([CALLBACK_TIMEOUT]).
-pub async fn start_callback_server() -> Result<(
-    String,
-    futures::channel::oneshot::Receiver<Result<OAuthCallback>>,
-)> {
-    let server = tiny_http::Server::http("127.0.0.1:0")
-        .map_err(|e| anyhow!(e).context("Failed to bind loopback listener for OAuth callback"))?;
-    let port = server
-        .server_addr()
-        .to_ip()
-        .context("server not bound to a TCP address")?
-        .port();
-
-    let redirect_uri = format!("http://127.0.0.1:{}/callback", port);
-
-    let (tx, rx) = futures::channel::oneshot::channel();
-
-    // `tiny_http` is blocking, so we run it on a background thread.
-    // The `recv_timeout` loop lets us check for cancellation (the receiver
-    // being dropped) and enforce an overall timeout.
-    std::thread::spawn(move || {
-        let deadline = std::time::Instant::now() + CALLBACK_TIMEOUT;
-
-        loop {
-            if tx.is_canceled() {
-                return;
-            }
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                return;
-            }
-
-            let timeout = remaining.min(Duration::from_millis(500));
-            let Some(request) = (match server.recv_timeout(timeout) {
-                Ok(req) => req,
-                Err(_) => {
-                    let _ = tx.send(Err(anyhow!("OAuth callback server I/O error")));
-                    return;
-                }
-            }) else {
-                // Timeout with no request — loop back and check cancellation.
-                continue;
-            };
-
-            let result = handle_callback_request(&request);
-
-            let (status_code, body) = match &result {
-                Ok(_) => (
-                    200,
-                    "<html><body><h1>Authorization successful</h1>\
-                     <p>You can close this tab and return to Zed.</p></body></html>",
-                ),
-                Err(err) => {
-                    log::error!("OAuth callback error: {}", err);
-                    (
-                        400,
-                        "<html><body><h1>Authorization failed</h1>\
-                         <p>Something went wrong. Please try again from Zed.</p></body></html>",
-                    )
-                }
-            };
-
-            let response = tiny_http::Response::from_string(body)
-                .with_status_code(status_code)
-                .with_header(
-                    tiny_http::Header::from_str("Content-Type: text/html")
-                        .expect("failed to construct response header"),
-                )
-                .with_header(
-                    tiny_http::Header::from_str("Keep-Alive: timeout=0,max=0")
-                        .expect("failed to construct response header"),
-                );
-            request.respond(response).log_err();
-
-            let _ = tx.send(result);
-            return;
+/// The callback server shuts down when the returned future is dropped (e.g.
+/// because the authentication task was cancelled), or after a timeout.
+pub fn start_callback_server() -> Result<(String, BoxFuture<'static, Result<OAuthCallback>>)> {
+    let (redirect_uri, rx) = oauth_callback_server::start_oauth_callback_server()?;
+    let future = async move {
+        match rx.await {
+            Ok(Ok(params)) => Ok(OAuthCallback {
+                code: params.code,
+                state: params.state,
+            }),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(anyhow!(
+                "OAuth callback server was shut down before receiving a response"
+            )),
         }
-    });
-
-    Ok((redirect_uri, rx))
-}
-
-/// Extract the `code` and `state` query parameters from an OAuth callback
-/// request to `/callback`.
-fn handle_callback_request(request: &tiny_http::Request) -> Result<OAuthCallback> {
-    let url = Url::parse(&format!("http://localhost{}", request.url()))
-        .context("malformed callback request URL")?;
-
-    if url.path() != "/callback" {
-        bail!("unexpected path in OAuth callback: {}", url.path());
     }
-
-    let query = url
-        .query()
-        .ok_or_else(|| anyhow!("OAuth callback has no query string"))?;
-    OAuthCallback::parse_query(query)
+    .boxed();
+    Ok((redirect_uri, future))
 }
 
 // -- JSON fetch helper -------------------------------------------------------

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -227,19 +227,60 @@ struct WatcherRegistrationState {
     mode: WatcherMode,
 }
 
+struct PathRegistrationState {
+    count: u32,
+    has_os_watcher: bool,
+}
+
 struct WatcherState {
     watchers: HashMap<WatcherRegistrationId, WatcherRegistrationState>,
-    native_path_registrations: HashMap<Arc<std::path::Path>, u32>,
-    poll_path_registrations: HashMap<Arc<std::path::Path>, u32>,
+    native_path_registrations: HashMap<Arc<std::path::Path>, PathRegistrationState>,
+    poll_path_registrations: HashMap<Arc<std::path::Path>, PathRegistrationState>,
     last_registration: WatcherRegistrationId,
 }
 
 impl WatcherState {
-    fn path_registrations(&mut self, mode: WatcherMode) -> &mut HashMap<Arc<std::path::Path>, u32> {
+    fn path_registrations(
+        &mut self,
+        mode: WatcherMode,
+    ) -> &mut HashMap<Arc<std::path::Path>, PathRegistrationState> {
         match mode {
             WatcherMode::Native => &mut self.native_path_registrations,
             WatcherMode::Poll => &mut self.poll_path_registrations,
         }
+    }
+
+    fn remove_registration(
+        &mut self,
+        id: WatcherRegistrationId,
+    ) -> Option<(Arc<std::path::Path>, WatcherMode)> {
+        let registration_state = self.watchers.remove(&id)?;
+        let path_registrations = self.path_registrations(registration_state.mode);
+        let count = path_registrations.get_mut(&registration_state.path)?;
+        count.count -= 1;
+        if count.count != 0 {
+            return None;
+        }
+
+        let was_actually_watched = count.has_os_watcher;
+        path_registrations.remove(&registration_state.path);
+
+        was_actually_watched.then_some((registration_state.path, registration_state.mode))
+    }
+}
+
+trait WatchBackend: Send {
+    fn watch(&mut self, path: &Path, mode: notify::RecursiveMode) -> notify::Result<()>;
+    fn unwatch(&mut self, path: &Path) -> notify::Result<()>;
+}
+
+impl<T: notify::Watcher + Send> WatchBackend for T {
+    fn watch(&mut self, path: &Path, mode: notify::RecursiveMode) -> notify::Result<()> {
+        notify::Watcher::watch(self, path, mode)
+    }
+
+    fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+        notify::Watcher::unwatch(self, path)
     }
 }
 
@@ -248,8 +289,8 @@ pub struct GlobalWatcher {
 
     // DANGER: never keep state lock while holding watcher lock
     // two mutexes because calling watcher.add triggers watcher.event, which needs watchers.
-    native_watcher: Mutex<Option<notify::RecommendedWatcher>>,
-    poll_watcher: Mutex<Option<notify::PollWatcher>>,
+    native_watcher: Mutex<Option<Box<dyn WatchBackend>>>,
+    poll_watcher: Mutex<Option<Box<dyn WatchBackend>>>,
 }
 
 impl GlobalWatcher {
@@ -280,41 +321,28 @@ impl GlobalWatcher {
             mode,
         };
         state.watchers.insert(id, registration_state);
-        *state.path_registrations(mode).entry(path).or_insert(0) += 1;
+        state
+            .path_registrations(mode)
+            .entry(path)
+            .and_modify(|registration| registration.count += 1)
+            .or_insert(PathRegistrationState {
+                count: 1,
+                has_os_watcher: !path_already_covered,
+            });
 
         Ok(id)
     }
 
     pub fn remove(&self, id: WatcherRegistrationId) {
         let mut state = self.state.lock();
-        let Some(registration_state) = state.watchers.remove(&id) else {
+        let Some((path, mode)) = state.remove_registration(id) else {
             return;
         };
-
-        let path_registrations = state.path_registrations(registration_state.mode);
-        let Some(count) = path_registrations.get_mut(&registration_state.path) else {
-            return;
-        };
-        *count -= 1;
-        if *count == 0 {
-            path_registrations.remove(&registration_state.path);
-            let path_still_covered = path_already_covered(
-                registration_state.path.as_ref(),
-                path_registrations,
-                registration_state.mode,
-            );
-
-            if !path_still_covered {
-                drop(state);
-                self.unwatch(&registration_state.path, registration_state.mode)
-                    .log_err();
-            }
-        }
+        drop(state);
+        self.unwatch(&path, mode).log_err();
     }
 
     fn watch(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
-        use notify::Watcher;
-
         match mode {
             WatcherMode::Native => {
                 self.ensure_native_watcher()?;
@@ -345,8 +373,6 @@ impl GlobalWatcher {
     }
 
     fn unwatch(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
-        use notify::Watcher;
-
         match mode {
             WatcherMode::Native => {
                 if let Some(watcher) = self.native_watcher.lock().as_mut() {
@@ -369,7 +395,7 @@ impl GlobalWatcher {
         }
 
         let watcher = notify::recommended_watcher(handle_native_event)?;
-        *self.native_watcher.lock() = Some(watcher);
+        *self.native_watcher.lock() = Some(Box::new(watcher));
         Ok(())
     }
 
@@ -380,14 +406,14 @@ impl GlobalWatcher {
 
         let config = notify::Config::default().with_poll_interval(*POLL_INTERVAL);
         let watcher = notify::PollWatcher::new(handle_poll_event, config)?;
-        *self.poll_watcher.lock() = Some(watcher);
+        *self.poll_watcher.lock() = Some(Box::new(watcher));
         Ok(())
     }
 }
 
 fn path_already_covered(
     path: &Path,
-    path_registrations: &HashMap<Arc<std::path::Path>, u32>,
+    path_registrations: &HashMap<Arc<std::path::Path>, PathRegistrationState>,
     mode: WatcherMode,
 ) -> bool {
     (mode == WatcherMode::Poll || cfg!(any(target_os = "windows", target_os = "macos")))
@@ -470,7 +496,7 @@ fn handle_event(mode: WatcherMode, event: Result<notify::Event, notify::Error>) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::{collections::HashSet, path::PathBuf};
 
     fn rescan(path: &str) -> PathEvent {
         PathEvent {
@@ -486,12 +512,77 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FakeWatchBackend {
+        watched_paths: HashSet<PathBuf>,
+        watch_calls: Vec<PathBuf>,
+        unwatch_calls: Vec<PathBuf>,
+    }
+
+    struct SharedFakeWatchBackend(Arc<Mutex<FakeWatchBackend>>);
+
+    impl WatchBackend for SharedFakeWatchBackend {
+        fn watch(&mut self, path: &Path, _mode: notify::RecursiveMode) -> notify::Result<()> {
+            let path = path.to_path_buf();
+            let mut backend = self.0.lock();
+            backend.watch_calls.push(path.clone());
+            backend.watched_paths.insert(path);
+            Ok(())
+        }
+
+        fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+            let path = path.to_path_buf();
+            let mut backend = self.0.lock();
+            backend.unwatch_calls.push(path.clone());
+            if backend.watched_paths.remove(&path) {
+                Ok(())
+            } else {
+                Err(notify::Error::generic("path was not watched"))
+            }
+        }
+    }
+
+    fn test_watcher(poll_watcher: Arc<Mutex<FakeWatchBackend>>) -> GlobalWatcher {
+        GlobalWatcher {
+            state: Mutex::new(WatcherState {
+                watchers: Default::default(),
+                native_path_registrations: Default::default(),
+                poll_path_registrations: Default::default(),
+                last_registration: Default::default(),
+            }),
+            native_watcher: Mutex::new(None),
+            poll_watcher: Mutex::new(Some(Box::new(SharedFakeWatchBackend(poll_watcher)))),
+        }
+    }
+
     struct TestCase {
         name: &'static str,
         pending_paths: Vec<PathEvent>,
         path_events: Vec<PathEvent>,
         expected_pending_paths: Vec<PathEvent>,
         expected_path_events: Vec<PathEvent>,
+    }
+
+    #[test]
+    fn covered_child_registration_is_not_unwatched_after_parent_is_removed() {
+        let backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let watcher = test_watcher(backend.clone());
+        let parent = Arc::<Path>::from(Path::new("/repo"));
+        let child = Arc::<Path>::from(Path::new("/repo/foo.csproj"));
+
+        let parent_registration = watcher
+            .add(parent.as_ref().into(), WatcherMode::Poll, |_| {})
+            .expect("add parent watch");
+        let child_registration = watcher
+            .add(child.as_ref().into(), WatcherMode::Poll, |_| {})
+            .expect("add covered child watch");
+
+        watcher.remove(parent_registration);
+        watcher.remove(child_registration);
+
+        let backend = backend.lock();
+        assert_eq!(backend.watch_calls, &[parent.to_path_buf()]);
+        assert_eq!(backend.unwatch_calls, &[parent.to_path_buf()]);
     }
 
     #[test]

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -468,6 +468,7 @@ pub enum ModelMode {
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     Medium,

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -47,19 +47,24 @@ lmstudio = { workspace = true, features = ["schemars"] }
 log.workspace = true
 menu.workspace = true
 mistral = { workspace = true, features = ["schemars"] }
+oauth_callback_server.workspace = true
 ollama = { workspace = true, features = ["schemars"] }
 open_ai = { workspace = true, features = ["schemars"] }
 opencode = { workspace = true, features = ["schemars"] }
 open_router = { workspace = true, features = ["schemars"] }
+rand.workspace = true
 release_channel.workspace = true
 schemars.workspace = true
+sha2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+smol.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 ui.workspace = true
 ui_input.workspace = true
+url.workspace = true
 util.workspace = true
 x_ai = { workspace = true, features = ["schemars"] }
 
@@ -71,5 +76,6 @@ feature_flags.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
+parking_lot.workspace = true
 pretty_assertions.workspace = true
 settings = { workspace = true, features = ["test-support"] }

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -27,6 +27,7 @@ use crate::provider::ollama::OllamaLanguageModelProvider;
 use crate::provider::open_ai::OpenAiLanguageModelProvider;
 use crate::provider::open_ai_compatible::OpenAiCompatibleLanguageModelProvider;
 use crate::provider::open_router::OpenRouterLanguageModelProvider;
+use crate::provider::openai_subscribed::OpenAiSubscribedProvider;
 use crate::provider::opencode::OpenCodeLanguageModelProvider;
 use crate::provider::vercel_ai_gateway::VercelAiGatewayLanguageModelProvider;
 use crate::provider::x_ai::XAiLanguageModelProvider;
@@ -324,10 +325,18 @@ fn register_language_model_providers(
     registry.register_provider(
         Arc::new(OpenCodeLanguageModelProvider::new(
             client.http_client(),
-            credentials_provider,
+            credentials_provider.clone(),
             cx,
         )),
         cx,
     );
     registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+    registry.register_provider(
+        Arc::new(OpenAiSubscribedProvider::new(
+            client.http_client(),
+            credentials_provider,
+            cx,
+        )),
+        cx,
+    );
 }

--- a/crates/language_models/src/provider.rs
+++ b/crates/language_models/src/provider.rs
@@ -10,6 +10,7 @@ pub mod ollama;
 pub mod open_ai;
 pub mod open_ai_compatible;
 pub mod open_router;
+pub mod openai_subscribed;
 pub mod opencode;
 
 pub mod vercel_ai_gateway;

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -383,6 +383,7 @@ impl OpenAiLanguageModel {
                 &api_url,
                 &api_key,
                 request,
+                vec![],
             );
             let response = request.await?;
             Ok(response)

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -217,6 +217,107 @@ impl LanguageModelProvider for OpenAiLanguageModelProvider {
     }
 }
 
+fn default_thinking_reasoning_effort(model: &open_ai::Model) -> Option<open_ai::ReasoningEffort> {
+    use open_ai::ReasoningEffort;
+
+    model
+        .reasoning_effort()
+        .filter(|effort| *effort != ReasoningEffort::None)
+        .or_else(|| {
+            let supported_efforts = model.supported_reasoning_efforts();
+            if supported_efforts.contains(&ReasoningEffort::Medium) {
+                Some(ReasoningEffort::Medium)
+            } else {
+                supported_efforts
+                    .iter()
+                    .copied()
+                    .find(|effort| *effort != ReasoningEffort::None)
+            }
+        })
+}
+
+fn supports_selectable_thinking_effort(model: &open_ai::Model) -> bool {
+    model.uses_responses_api()
+        && model
+            .supported_reasoning_efforts()
+            .iter()
+            .any(|effort| *effort != open_ai::ReasoningEffort::None)
+}
+
+fn supported_thinking_effort_levels(model: &open_ai::Model) -> Vec<LanguageModelEffortLevel> {
+    if !supports_selectable_thinking_effort(model) {
+        return Vec::new();
+    }
+
+    let default_effort = default_thinking_reasoning_effort(model);
+    model
+        .supported_reasoning_efforts()
+        .iter()
+        .copied()
+        .filter_map(|effort| {
+            let (name, value) = match effort {
+                open_ai::ReasoningEffort::None => return None,
+                open_ai::ReasoningEffort::Minimal => ("Minimal", "minimal"),
+                open_ai::ReasoningEffort::Low => ("Low", "low"),
+                open_ai::ReasoningEffort::Medium => ("Medium", "medium"),
+                open_ai::ReasoningEffort::High => ("High", "high"),
+                open_ai::ReasoningEffort::XHigh => ("Extra High", "xhigh"),
+            };
+
+            Some(LanguageModelEffortLevel {
+                name: name.into(),
+                value: value.into(),
+                is_default: Some(effort) == default_effort,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_thinking_effort_levels_hide_none() {
+        let effort_levels = supported_thinking_effort_levels(&open_ai::Model::FivePointTwo);
+        let values = effort_levels
+            .iter()
+            .map(|level| level.value.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["low", "medium", "high", "xhigh"]);
+        assert_eq!(
+            effort_levels
+                .iter()
+                .find(|level| level.is_default)
+                .map(|level| level.value.as_ref()),
+            Some("medium")
+        );
+    }
+
+    #[test]
+    fn models_supporting_only_none_have_no_selectable_thinking_effort() {
+        let model = open_ai::Model::Custom {
+            name: "custom-model".to_string(),
+            display_name: None,
+            max_tokens: 128_000,
+            max_output_tokens: None,
+            max_completion_tokens: None,
+            reasoning_effort: Some(open_ai::ReasoningEffort::None),
+            supports_chat_completions: false,
+            supports_images: true,
+        };
+
+        assert!(!supports_selectable_thinking_effort(&model));
+        assert!(supported_thinking_effort_levels(&model).is_empty());
+        assert!(
+            model
+                .supported_reasoning_efforts()
+                .contains(&open_ai::ReasoningEffort::None)
+        );
+    }
+}
+
 pub struct OpenAiLanguageModel {
     id: LanguageModelId,
     model: open_ai::Model,
@@ -316,22 +417,20 @@ impl LanguageModel for OpenAiLanguageModel {
         use open_ai::Model;
         match &self.model {
             Model::FourOmniMini
-            | Model::FourPointOneNano
             | Model::Five
-            | Model::FiveCodex
             | Model::FiveMini
             | Model::FiveNano
             | Model::FivePointOne
             | Model::FivePointTwo
-            | Model::FivePointTwoCodex
             | Model::FivePointThreeCodex
             | Model::FivePointFour
+            | Model::FivePointFourMini
+            | Model::FivePointFourNano
             | Model::FivePointFourPro
             | Model::FivePointFive
             | Model::FivePointFivePro
-            | Model::O1
             | Model::O3 => true,
-            Model::ThreePointFiveTurbo | Model::Four | Model::FourTurbo | Model::O3Mini => false,
+            Model::Four => false,
             Model::Custom {
                 supports_images, ..
             } => *supports_images,
@@ -351,34 +450,11 @@ impl LanguageModel for OpenAiLanguageModel {
     }
 
     fn supports_thinking(&self) -> bool {
-        self.model.uses_responses_api() && self.model.reasoning_effort().is_some()
+        supports_selectable_thinking_effort(&self.model)
     }
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
-        if !self.supports_thinking() {
-            return Vec::new();
-        }
-
-        let default_effort = self.model.reasoning_effort();
-        self.model
-            .supported_reasoning_efforts()
-            .iter()
-            .map(|effort| {
-                let (name, value) = match effort {
-                    open_ai::ReasoningEffort::Minimal => ("Minimal", "minimal"),
-                    open_ai::ReasoningEffort::Low => ("Low", "low"),
-                    open_ai::ReasoningEffort::Medium => ("Medium", "medium"),
-                    open_ai::ReasoningEffort::High => ("High", "high"),
-                    open_ai::ReasoningEffort::XHigh => ("Extra High", "xhigh"),
-                };
-
-                LanguageModelEffortLevel {
-                    name: name.into(),
-                    value: value.into(),
-                    is_default: Some(*effort) == default_effort,
-                }
-            })
-            .collect()
+        supported_thinking_effort_levels(&self.model)
     }
 
     fn supports_split_token_display(&self) -> bool {
@@ -418,7 +494,10 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
                 self.max_output_tokens(),
-                self.model.reasoning_effort(),
+                default_thinking_reasoning_effort(&self.model),
+                self.model
+                    .supported_reasoning_efforts()
+                    .contains(&open_ai::ReasoningEffort::None),
             );
             let completions = self.stream_response(request, cx);
             async move {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -6,10 +6,10 @@ use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, TaskExt,
 use http_client::HttpClient;
 use language_model::{
     ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel, LanguageModelCompletionError,
-    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
-    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
-    LanguageModelRequest, LanguageModelToolChoice, OPEN_AI_PROVIDER_ID, OPEN_AI_PROVIDER_NAME,
-    RateLimiter, env_var,
+    LanguageModelCompletionEvent, LanguageModelEffortLevel, LanguageModelId, LanguageModelName,
+    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
+    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice, OPEN_AI_PROVIDER_ID,
+    OPEN_AI_PROVIDER_NAME, RateLimiter, env_var,
 };
 use menu;
 use open_ai::{
@@ -351,7 +351,34 @@ impl LanguageModel for OpenAiLanguageModel {
     }
 
     fn supports_thinking(&self) -> bool {
-        self.model.reasoning_effort().is_some()
+        self.model.uses_responses_api() && self.model.reasoning_effort().is_some()
+    }
+
+    fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
+        if !self.supports_thinking() {
+            return Vec::new();
+        }
+
+        let default_effort = self.model.reasoning_effort();
+        self.model
+            .supported_reasoning_efforts()
+            .iter()
+            .map(|effort| {
+                let (name, value) = match effort {
+                    open_ai::ReasoningEffort::Minimal => ("Minimal", "minimal"),
+                    open_ai::ReasoningEffort::Low => ("Low", "low"),
+                    open_ai::ReasoningEffort::Medium => ("Medium", "medium"),
+                    open_ai::ReasoningEffort::High => ("High", "high"),
+                    open_ai::ReasoningEffort::XHigh => ("Extra High", "xhigh"),
+                };
+
+                LanguageModelEffortLevel {
+                    name: name.into(),
+                    value: value.into(),
+                    is_default: Some(*effort) == default_effort,
+                }
+            })
+            .collect()
     }
 
     fn supports_split_token_display(&self) -> bool {
@@ -406,7 +433,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
                 self.max_output_tokens(),
-                self.model.reasoning_effort(),
+                None,
                 false,
             );
             let completions = self.stream_completion(request, cx);

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -289,6 +289,7 @@ impl OpenAiCompatibleLanguageModel {
                 &api_url,
                 &api_key,
                 request,
+                vec![],
             );
             let response = request.await?;
             Ok(response)

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -397,7 +397,10 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
                 self.max_output_tokens(),
-                self.model.reasoning_effort,
+                self.model
+                    .reasoning_effort
+                    .filter(|effort| *effort != open_ai::ReasoningEffort::None),
+                self.model.reasoning_effort == Some(open_ai::ReasoningEffort::None),
             );
             let completions = self.stream_response(request, cx);
             async move {

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -1,0 +1,1464 @@
+use anyhow::{Context as _, Result, anyhow};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use credentials_provider::CredentialsProvider;
+use futures::{FutureExt, StreamExt, future::BoxFuture, future::Shared};
+use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
+use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
+use language_model::{
+    AuthenticateError, IconOrSvg, LanguageModel, LanguageModelCompletionError,
+    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
+    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
+    LanguageModelRequest, LanguageModelToolChoice, RateLimiter,
+};
+use open_ai::{ReasoningEffort, responses::stream_response};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use ui::{ConfiguredApiCard, prelude::*};
+use url::form_urlencoded;
+use util::ResultExt as _;
+
+use crate::provider::open_ai::{OpenAiResponseEventMapper, into_open_ai_response};
+
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openai-subscribed");
+const PROVIDER_NAME: LanguageModelProviderName =
+    LanguageModelProviderName::new("ChatGPT Subscription");
+
+const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const OPENAI_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const OPENAI_AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+const CREDENTIALS_KEY: &str = "https://chatgpt.com/backend-api/codex";
+const TOKEN_REFRESH_BUFFER_MS: u64 = 5 * 60 * 1000;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct CodexCredentials {
+    access_token: String,
+    refresh_token: String,
+    expires_at_ms: u64,
+    account_id: Option<String>,
+    email: Option<String>,
+}
+
+impl CodexCredentials {
+    fn is_expired(&self) -> bool {
+        let now = now_ms();
+        now + TOKEN_REFRESH_BUFFER_MS >= self.expires_at_ms
+    }
+}
+
+pub struct State {
+    credentials: Option<CodexCredentials>,
+    sign_in_task: Option<Task<Result<()>>>,
+    refresh_task: Option<Shared<Task<Result<CodexCredentials, Arc<anyhow::Error>>>>>,
+    load_task: Option<Shared<Task<Result<(), Arc<anyhow::Error>>>>>,
+    credentials_provider: Arc<dyn CredentialsProvider>,
+    auth_generation: u64,
+    last_auth_error: Option<SharedString>,
+}
+
+#[derive(Debug)]
+enum RefreshError {
+    Fatal(anyhow::Error),
+    Transient(anyhow::Error),
+}
+
+impl std::fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefreshError::Fatal(e) => write!(f, "{e}"),
+            RefreshError::Transient(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl State {
+    fn is_authenticated(&self) -> bool {
+        self.credentials.is_some()
+    }
+
+    fn email(&self) -> Option<&str> {
+        self.credentials.as_ref().and_then(|c| c.email.as_deref())
+    }
+
+    fn is_signing_in(&self) -> bool {
+        self.sign_in_task.is_some()
+    }
+}
+
+pub struct OpenAiSubscribedProvider {
+    http_client: Arc<dyn HttpClient>,
+    state: Entity<State>,
+}
+
+impl OpenAiSubscribedProvider {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        credentials_provider: Arc<dyn CredentialsProvider>,
+        cx: &mut App,
+    ) -> Self {
+        let state = cx.new(|_cx| State {
+            credentials: None,
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider,
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let provider = Self { http_client, state };
+
+        provider.load_credentials(cx);
+
+        provider
+    }
+
+    fn load_credentials(&self, cx: &mut App) {
+        let state = self.state.downgrade();
+        let load_task = cx
+            .spawn(async move |cx| {
+                let credentials_provider =
+                    state.read_with(&*cx, |s, _| s.credentials_provider.clone())?;
+                let result = credentials_provider
+                    .read_credentials(CREDENTIALS_KEY, &*cx)
+                    .await;
+                state.update(cx, |s, cx| {
+                    if let Ok(Some((_, bytes))) = result {
+                        match serde_json::from_slice::<CodexCredentials>(&bytes) {
+                            Ok(creds) => s.credentials = Some(creds),
+                            Err(err) => {
+                                log::warn!(
+                                    "Failed to deserialize ChatGPT subscription credentials: {err}"
+                                );
+                            }
+                        }
+                    }
+                    s.load_task = None;
+                    cx.notify();
+                })?;
+                Ok::<(), Arc<anyhow::Error>>(())
+            })
+            .shared();
+
+        self.state.update(cx, |s, _| {
+            s.load_task = Some(load_task);
+        });
+    }
+
+    fn sign_out(&self, cx: &mut App) -> Task<Result<()>> {
+        do_sign_out(&self.state.downgrade(), cx)
+    }
+
+    fn create_language_model(&self, model: ChatGptModel) -> Arc<dyn LanguageModel> {
+        Arc::new(OpenAiSubscribedLanguageModel {
+            id: LanguageModelId::from(model.id().to_string()),
+            model,
+            state: self.state.clone(),
+            http_client: self.http_client.clone(),
+            request_limiter: RateLimiter::new(4),
+        })
+    }
+}
+
+impl LanguageModelProviderState for OpenAiSubscribedProvider {
+    type ObservableEntity = State;
+
+    fn observable_entity(&self) -> Option<Entity<Self::ObservableEntity>> {
+        Some(self.state.clone())
+    }
+}
+
+impl LanguageModelProvider for OpenAiSubscribedProvider {
+    fn id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn icon(&self) -> IconOrSvg {
+        IconOrSvg::Icon(IconName::AiOpenAi)
+    }
+
+    fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(ChatGptModel::Gpt55))
+    }
+
+    fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        // No GPT-5.5 Mini exists yet; per the OpenAI Codex docs, gpt-5.4-mini
+        // is the recommended fast/cheap default alongside gpt-5.5.
+        Some(self.create_language_model(ChatGptModel::Gpt54Mini))
+    }
+
+    fn provided_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {
+        ChatGptModel::all()
+            .into_iter()
+            .map(|m| self.create_language_model(m))
+            .collect()
+    }
+
+    fn is_authenticated(&self, cx: &App) -> bool {
+        self.state.read(cx).is_authenticated()
+    }
+
+    fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
+        if self.is_authenticated(cx) {
+            return Task::ready(Ok(()));
+        }
+        let load_task = self.state.read(cx).load_task.clone();
+        if let Some(load_task) = load_task {
+            let weak_state = self.state.downgrade();
+            cx.spawn(async move |cx| {
+                let _ = load_task.await;
+                let is_auth = weak_state
+                    .read_with(&*cx, |s, _| s.is_authenticated())
+                    .unwrap_or(false);
+                if is_auth {
+                    Ok(())
+                } else {
+                    Err(anyhow!(
+                        "Sign in with your ChatGPT Plus or Pro subscription to use this provider."
+                    )
+                    .into())
+                }
+            })
+        } else {
+            Task::ready(Err(anyhow!(
+                "Sign in with your ChatGPT Plus or Pro subscription to use this provider."
+            )
+            .into()))
+        }
+    }
+
+    fn configuration_view(
+        &self,
+        _target_agent: language_model::ConfigurationViewTargetAgent,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> AnyView {
+        let state = self.state.clone();
+        let http_client = self.http_client.clone();
+        cx.new(|_cx| ConfigurationView { state, http_client })
+            .into()
+    }
+
+    fn reset_credentials(&self, cx: &mut App) -> Task<Result<()>> {
+        self.sign_out(cx)
+    }
+}
+
+//
+// The ChatGPT Subscription provider routes requests to chatgpt.com/backend-api/codex,
+// which only supports a subset of OpenAI models. This list is maintained separately
+// from the standard OpenAI API model list (open_ai::Model).
+//
+// TODO: The Codex CLI fetches this list dynamically from
+// `GET <codex_base_url>/models?client_version=...` (see
+// codex-rs/codex-api/src/endpoint/models.rs in openai/codex) and falls back to
+// a bundled models.json. Beyond going stale, the static approach also can't
+// model per-account access (e.g. free accounts cannot use gpt-5.4 or
+// gpt-5.3-codex even though paid accounts can), so the backend still rejects
+// some requests. The bundled list at
+// codex-rs/models-manager/models.json (openai/codex) is the closest
+// approximation; the entries below mirror that file's picker-visible models.
+#[derive(Clone, Debug, PartialEq)]
+enum ChatGptModel {
+    Gpt55,
+    Gpt54,
+    Gpt54Mini,
+    Gpt53Codex,
+    Gpt52,
+}
+
+impl ChatGptModel {
+    fn all() -> Vec<Self> {
+        vec![
+            Self::Gpt55,
+            Self::Gpt54,
+            Self::Gpt54Mini,
+            Self::Gpt53Codex,
+            Self::Gpt52,
+        ]
+    }
+
+    fn id(&self) -> &str {
+        match self {
+            Self::Gpt55 => "gpt-5.5",
+            Self::Gpt54 => "gpt-5.4",
+            Self::Gpt54Mini => "gpt-5.4-mini",
+            Self::Gpt53Codex => "gpt-5.3-codex",
+            Self::Gpt52 => "gpt-5.2",
+        }
+    }
+
+    fn display_name(&self) -> &str {
+        match self {
+            Self::Gpt55 => "GPT-5.5",
+            Self::Gpt54 => "GPT-5.4",
+            Self::Gpt54Mini => "GPT-5.4 Mini",
+            Self::Gpt53Codex => "GPT-5.3 Codex",
+            Self::Gpt52 => "GPT-5.2",
+        }
+    }
+
+    fn max_token_count(&self) -> u64 {
+        // All Codex-supported models share the backend's 272K input cap, even
+        // when the raw model exposes a larger context window via the public
+        // API (e.g. gpt-5.4 has max_context_window 1M, but the Codex backend
+        // caps it at 272K). Source: openai/codex models-manager/models.json.
+        272_000
+    }
+
+    fn max_output_tokens(&self) -> Option<u64> {
+        Some(128_000)
+    }
+
+    fn supports_images(&self) -> bool {
+        true
+    }
+
+    fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        // Codex bundled models all default to Medium reasoning effort.
+        Some(ReasoningEffort::Medium)
+    }
+
+    fn supports_none_reasoning_effort(&self) -> bool {
+        // The Codex backend's supported_reasoning_levels for every model in
+        // this list is low/medium/high/xhigh -- sending `none` is rejected.
+        false
+    }
+
+    fn supports_parallel_tool_calls(&self) -> bool {
+        true
+    }
+
+    fn supports_prompt_cache_key(&self) -> bool {
+        true
+    }
+}
+
+struct OpenAiSubscribedLanguageModel {
+    id: LanguageModelId,
+    model: ChatGptModel,
+    state: Entity<State>,
+    http_client: Arc<dyn HttpClient>,
+    request_limiter: RateLimiter,
+}
+
+impl LanguageModel for OpenAiSubscribedLanguageModel {
+    fn id(&self) -> LanguageModelId {
+        self.id.clone()
+    }
+
+    fn name(&self) -> LanguageModelName {
+        LanguageModelName::from(self.model.display_name().to_string())
+    }
+
+    fn provider_id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn provider_name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn supports_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_images(&self) -> bool {
+        self.model.supports_images()
+    }
+
+    fn supports_tool_choice(&self, _choice: LanguageModelToolChoice) -> bool {
+        true
+    }
+
+    fn supports_streaming_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_thinking(&self) -> bool {
+        self.model.reasoning_effort().is_some()
+    }
+
+    fn telemetry_id(&self) -> String {
+        format!("openai-subscribed/{}", self.model.id())
+    }
+
+    fn max_token_count(&self) -> u64 {
+        self.model.max_token_count()
+    }
+
+    fn max_output_tokens(&self) -> Option<u64> {
+        self.model.max_output_tokens()
+    }
+
+    fn stream_completion(
+        &self,
+        request: LanguageModelRequest,
+        cx: &AsyncApp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            futures::stream::BoxStream<
+                'static,
+                Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+            >,
+            LanguageModelCompletionError,
+        >,
+    > {
+        // The Codex backend rejects `max_output_tokens` (`Unsupported parameter`),
+        // unlike the public OpenAI Responses API. Pass `None` so the field is
+        // omitted from the serialized request body entirely.
+        let mut responses_request = into_open_ai_response(
+            request,
+            self.model.id(),
+            self.model.supports_parallel_tool_calls(),
+            self.model.supports_prompt_cache_key(),
+            /*max_output_tokens*/ None,
+            self.model.reasoning_effort(),
+            self.model.supports_none_reasoning_effort(),
+        );
+        responses_request.store = Some(false);
+
+        // The Codex backend requires system messages to be in the top-level
+        // `instructions` field rather than as input items.
+        let mut instructions = Vec::new();
+        responses_request.input.retain(|item| {
+            if let open_ai::responses::ResponseInputItem::Message(msg) = item {
+                if msg.role == open_ai::Role::System {
+                    for part in &msg.content {
+                        if let open_ai::responses::ResponseInputContent::Text { text } = part {
+                            instructions.push(text.clone());
+                        }
+                    }
+                    return false;
+                }
+            }
+            true
+        });
+        if !instructions.is_empty() {
+            responses_request.instructions = Some(instructions.join("\n\n"));
+        }
+
+        let state = self.state.downgrade();
+        let http_client = self.http_client.clone();
+        let request_limiter = self.request_limiter.clone();
+
+        let future = cx.spawn(async move |cx| {
+            let creds = get_fresh_credentials(&state, &http_client, cx).await?;
+
+            let mut extra_headers: Vec<(String, String)> = vec![
+                ("originator".into(), "zed".into()),
+                ("OpenAI-Beta".into(), "responses=experimental".into()),
+            ];
+            if let Some(ref id) = creds.account_id {
+                if !id.is_empty() {
+                    extra_headers.push(("ChatGPT-Account-Id".into(), id.clone()));
+                }
+            }
+
+            let access_token = creds.access_token.clone();
+            request_limiter
+                .stream(async move {
+                    stream_response(
+                        http_client.as_ref(),
+                        PROVIDER_NAME.0.as_str(),
+                        CODEX_BASE_URL,
+                        &access_token,
+                        responses_request,
+                        extra_headers,
+                    )
+                    .await
+                    .map_err(LanguageModelCompletionError::from)
+                })
+                .await
+        });
+
+        async move {
+            let mapper = OpenAiResponseEventMapper::new();
+            Ok(mapper.map_stream(future.await?.boxed()).boxed())
+        }
+        .boxed()
+    }
+}
+
+async fn get_fresh_credentials(
+    state: &gpui::WeakEntity<State>,
+    http_client: &Arc<dyn HttpClient>,
+    cx: &mut AsyncApp,
+) -> Result<CodexCredentials, LanguageModelCompletionError> {
+    let (creds, existing_task) = state
+        .read_with(&*cx, |s, _| (s.credentials.clone(), s.refresh_task.clone()))
+        .map_err(LanguageModelCompletionError::Other)?;
+
+    let creds = creds.ok_or(LanguageModelCompletionError::NoApiKey {
+        provider: PROVIDER_NAME,
+    })?;
+
+    if !creds.is_expired() {
+        return Ok(creds);
+    }
+
+    // If another caller is already refreshing, await their result.
+    if let Some(shared_task) = existing_task {
+        return shared_task
+            .await
+            .map_err(|e| LanguageModelCompletionError::Other(anyhow::anyhow!("{e}")));
+    }
+
+    // We are the first caller to notice expiry — spawn the refresh task.
+    let http_client_clone = http_client.clone();
+    let state_clone = state.clone();
+    let refresh_token_value = creds.refresh_token.clone();
+
+    // Capture the generation so we can detect sign-outs that happened during refresh.
+    let generation = state
+        .read_with(&*cx, |s, _| s.auth_generation)
+        .map_err(LanguageModelCompletionError::Other)?;
+
+    let shared_task = cx
+        .spawn(async move |cx| {
+            let result = refresh_token(&http_client_clone, &refresh_token_value).await;
+
+            match result {
+                Ok(refreshed) => {
+                    let persist_result: Result<CodexCredentials, Arc<anyhow::Error>> = async {
+                        // Check if auth_generation changed (sign-out during refresh).
+                        let current_generation = state_clone
+                            .read_with(&*cx, |s, _| s.auth_generation)
+                            .map_err(|e| Arc::new(e))?;
+                        if current_generation != generation {
+                            return Err(Arc::new(anyhow!(
+                                "Sign-out occurred during token refresh"
+                            )));
+                        }
+
+                        let credentials_provider = state_clone
+                            .read_with(&*cx, |s, _| s.credentials_provider.clone())
+                            .map_err(|e| Arc::new(e))?;
+
+                        let json =
+                            serde_json::to_vec(&refreshed).map_err(|e| Arc::new(e.into()))?;
+
+                        credentials_provider
+                            .write_credentials(CREDENTIALS_KEY, "Bearer", &json, &*cx)
+                            .await
+                            .map_err(|e| Arc::new(e))?;
+
+                        state_clone
+                            .update(cx, |s, _| {
+                                s.credentials = Some(refreshed.clone());
+                                s.refresh_task = None;
+                            })
+                            .map_err(|e| Arc::new(e))?;
+
+                        Ok(refreshed)
+                    }
+                    .await;
+
+                    // Clear refresh_task on failure too.
+                    if persist_result.is_err() {
+                        let _ = state_clone.update(cx, |s, _| {
+                            s.refresh_task = None;
+                        });
+                    }
+
+                    persist_result
+                }
+                Err(RefreshError::Fatal(e)) => {
+                    log::error!("ChatGPT subscription token refresh failed fatally: {e:?}");
+                    let _ = state_clone.update(cx, |s, cx| {
+                        s.refresh_task = None;
+                        s.credentials = None;
+                        s.last_auth_error =
+                            Some("Your session has expired. Please sign in again.".into());
+                        cx.notify();
+                    });
+                    // Also clear the keychain so stale credentials aren't loaded next time.
+                    if let Ok(credentials_provider) =
+                        state_clone.read_with(&*cx, |s, _| s.credentials_provider.clone())
+                    {
+                        credentials_provider
+                            .delete_credentials(CREDENTIALS_KEY, &*cx)
+                            .await
+                            .log_err();
+                    }
+                    Err(Arc::new(e))
+                }
+                Err(RefreshError::Transient(e)) => {
+                    log::warn!("ChatGPT subscription token refresh failed transiently: {e:?}");
+                    let _ = state_clone.update(cx, |s, _| {
+                        s.refresh_task = None;
+                    });
+                    Err(Arc::new(e))
+                }
+            }
+        })
+        .shared();
+
+    // Store the shared task so concurrent callers can join on it.
+    state
+        .update(cx, |s, _| {
+            s.refresh_task = Some(shared_task.clone());
+        })
+        .map_err(LanguageModelCompletionError::Other)?;
+
+    shared_task
+        .await
+        .map_err(|e| LanguageModelCompletionError::Other(anyhow::anyhow!("{e}")))
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    #[serde(default)]
+    id_token: Option<String>,
+    expires_in: u64,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+// The OAuth client registered for `CLIENT_ID` (the Codex CLI's client) only allows
+// `http://localhost:1455/auth/callback` and `http://localhost:1457/auth/callback`
+// as redirect URIs; using anything else (different host, port, or path) causes
+// auth.openai.com to reject the authorize request with a generic `unknown_error`
+// before redirecting back. Keep these in sync with the Codex CLI's redirect URI
+// allow-list (see codex-rs/login/src/server.rs in openai/codex).
+const CODEX_CALLBACK_HOST: &str = "localhost";
+const CODEX_CALLBACK_PORT: u16 = 1455;
+const CODEX_CALLBACK_FALLBACK_PORT: u16 = 1457;
+const CODEX_CALLBACK_PATH: &str = "/auth/callback";
+
+async fn do_oauth_flow(
+    http_client: Arc<dyn HttpClient>,
+    cx: &AsyncApp,
+) -> Result<CodexCredentials> {
+    // Start the callback server FIRST so the redirect URI is ready
+    let (redirect_uri, callback_rx) =
+        oauth_callback_server::start_oauth_callback_server_with_config(
+            oauth_callback_server::OAuthCallbackServerConfig {
+                host: CODEX_CALLBACK_HOST,
+                preferred_port: CODEX_CALLBACK_PORT,
+                fallback_port: Some(CODEX_CALLBACK_FALLBACK_PORT),
+                path: CODEX_CALLBACK_PATH,
+            },
+        )
+        .context("Failed to start OAuth callback server")?;
+
+    // PKCE verifier: 32 random bytes → base64url (no padding)
+    let mut verifier_bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut verifier_bytes);
+    let verifier = URL_SAFE_NO_PAD.encode(verifier_bytes);
+
+    // PKCE challenge: SHA-256(verifier) → base64url
+    let mut hasher = Sha256::new();
+    hasher.update(verifier.as_bytes());
+    let challenge = URL_SAFE_NO_PAD.encode(hasher.finalize().as_slice());
+
+    // CSRF state: 16 random bytes → hex string
+    let mut state_bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut state_bytes);
+    let oauth_state: String = state_bytes.iter().map(|b| format!("{b:02x}")).collect();
+
+    let mut auth_url = url::Url::parse(OPENAI_AUTHORIZE_URL).expect("valid base URL");
+    auth_url
+        .query_pairs_mut()
+        .append_pair("client_id", CLIENT_ID)
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair(
+            "scope",
+            "openid profile email offline_access api.connectors.read api.connectors.invoke",
+        )
+        .append_pair("response_type", "code")
+        .append_pair("code_challenge", &challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("id_token_add_organizations", "true")
+        .append_pair("state", &oauth_state)
+        .append_pair("codex_cli_simplified_flow", "true")
+        .append_pair("originator", "zed");
+
+    // Open browser AFTER the listener is ready
+    cx.update(|cx| cx.open_url(auth_url.as_str()));
+
+    // Await the callback
+    let callback = callback_rx
+        .await
+        .map_err(|_| anyhow!("OAuth callback was cancelled"))?
+        .context("OAuth callback failed")?;
+
+    // Validate CSRF state
+    if callback.state != oauth_state {
+        return Err(anyhow!("OAuth state mismatch"));
+    }
+
+    let tokens = exchange_code(&http_client, &callback.code, &verifier, &redirect_uri)
+        .await
+        .context("Token exchange failed")?;
+
+    let jwt = tokens
+        .id_token
+        .as_deref()
+        .unwrap_or(tokens.access_token.as_str());
+    let claims = extract_jwt_claims(jwt);
+
+    Ok(CodexCredentials {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at_ms: now_ms() + tokens.expires_in * 1000,
+        account_id: claims.account_id,
+        email: claims.email.or(tokens.email),
+    })
+}
+
+async fn exchange_code(
+    client: &Arc<dyn HttpClient>,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<TokenResponse> {
+    let body = form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", "authorization_code")
+        .append_pair("client_id", CLIENT_ID)
+        .append_pair("code", code)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("code_verifier", verifier)
+        .finish();
+
+    let request = HttpRequest::builder()
+        .method(Method::POST)
+        .uri(OPENAI_TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(AsyncBody::from(body))?;
+
+    let mut response = client.send(request).await?;
+    let mut body = String::new();
+    smol::io::AsyncReadExt::read_to_string(response.body_mut(), &mut body).await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "Token exchange failed (HTTP {}): {body}",
+            response.status()
+        ));
+    }
+
+    serde_json::from_str::<TokenResponse>(&body).context("Failed to parse token response")
+}
+
+async fn refresh_token(
+    client: &Arc<dyn HttpClient>,
+    refresh_token: &str,
+) -> Result<CodexCredentials, RefreshError> {
+    let body = form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", "refresh_token")
+        .append_pair("client_id", CLIENT_ID)
+        .append_pair("refresh_token", refresh_token)
+        .finish();
+
+    let request = HttpRequest::builder()
+        .method(Method::POST)
+        .uri(OPENAI_TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(AsyncBody::from(body))
+        .map_err(|e| RefreshError::Transient(e.into()))?;
+
+    let mut response = client
+        .send(request)
+        .await
+        .map_err(|e| RefreshError::Transient(e))?;
+    let status = response.status();
+    let mut body = String::new();
+    smol::io::AsyncReadExt::read_to_string(response.body_mut(), &mut body)
+        .await
+        .map_err(|e| RefreshError::Transient(e.into()))?;
+
+    if !status.is_success() {
+        let err = anyhow!("Token refresh failed (HTTP {}): {body}", status);
+        // 400/401/403 indicate a revoked or invalid refresh token.
+        // 5xx and other errors are treated as transient.
+        if status == http_client::StatusCode::BAD_REQUEST
+            || status == http_client::StatusCode::UNAUTHORIZED
+            || status == http_client::StatusCode::FORBIDDEN
+        {
+            return Err(RefreshError::Fatal(err));
+        }
+        return Err(RefreshError::Transient(err));
+    }
+
+    let tokens: TokenResponse =
+        serde_json::from_str(&body).map_err(|e| RefreshError::Transient(e.into()))?;
+    let jwt = tokens
+        .id_token
+        .as_deref()
+        .unwrap_or(tokens.access_token.as_str());
+    let claims = extract_jwt_claims(jwt);
+
+    Ok(CodexCredentials {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at_ms: now_ms() + tokens.expires_in * 1000,
+        account_id: claims.account_id,
+        email: claims.email.or(tokens.email),
+    })
+}
+
+struct JwtClaims {
+    account_id: Option<String>,
+    email: Option<String>,
+}
+
+/// Extract claims from a JWT payload (base64url middle segment).
+/// Extracts `chatgpt_account_id` from three possible locations (matching Roo Code's
+/// implementation) and the `email` claim.
+fn extract_jwt_claims(jwt: &str) -> JwtClaims {
+    let Some(payload_b64) = jwt.split('.').nth(1) else {
+        return JwtClaims {
+            account_id: None,
+            email: None,
+        };
+    };
+    let Ok(payload) = URL_SAFE_NO_PAD.decode(payload_b64) else {
+        return JwtClaims {
+            account_id: None,
+            email: None,
+        };
+    };
+    let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&payload) else {
+        return JwtClaims {
+            account_id: None,
+            email: None,
+        };
+    };
+
+    let account_id = claims
+        .get("chatgpt_account_id")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            claims
+                .get("https://api.openai.com/auth")
+                .and_then(|v| v.get("chatgpt_account_id"))
+                .and_then(|v| v.as_str())
+        })
+        .or_else(|| {
+            claims
+                .get("organizations")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|org| org.get("id"))
+                .and_then(|v| v.as_str())
+        })
+        .map(|s| s.to_owned());
+
+    let email = claims
+        .get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned());
+
+    JwtClaims { account_id, email }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_else(|err| {
+            log::error!("System clock is before UNIX epoch: {err}");
+            0
+        })
+}
+
+fn do_sign_in(state: &Entity<State>, http_client: &Arc<dyn HttpClient>, cx: &mut App) {
+    if state.read(cx).is_signing_in() {
+        return;
+    }
+
+    let weak_state = state.downgrade();
+    let http_client = http_client.clone();
+
+    let task = cx.spawn(async move |cx| {
+        match do_oauth_flow(http_client, &*cx).await {
+            Ok(creds) => {
+                let persist_result = async {
+                    let credentials_provider =
+                        weak_state.read_with(&*cx, |s, _| s.credentials_provider.clone())?;
+                    let json = serde_json::to_vec(&creds)?;
+                    credentials_provider
+                        .write_credentials(CREDENTIALS_KEY, "Bearer", &json, &*cx)
+                        .await?;
+                    anyhow::Ok(())
+                }
+                .await;
+
+                match persist_result {
+                    Ok(()) => {
+                        weak_state
+                            .update(cx, |s, cx| {
+                                s.credentials = Some(creds);
+                                s.sign_in_task = None;
+                                s.last_auth_error = None;
+                                cx.notify();
+                            })
+                            .log_err();
+                    }
+                    Err(err) => {
+                        log::error!(
+                            "ChatGPT subscription sign-in failed to persist credentials: {err:?}"
+                        );
+                        weak_state
+                            .update(cx, |s, cx| {
+                                s.sign_in_task = None;
+                                s.last_auth_error =
+                                    Some("Failed to save credentials. Please try again.".into());
+                                cx.notify();
+                            })
+                            .log_err();
+                    }
+                }
+            }
+            Err(err) => {
+                log::error!("ChatGPT subscription sign-in failed: {err:?}");
+                weak_state
+                    .update(cx, |s, cx| {
+                        s.sign_in_task = None;
+                        s.last_auth_error = Some("Sign-in failed. Please try again.".into());
+                        cx.notify();
+                    })
+                    .log_err();
+            }
+        }
+        anyhow::Ok(())
+    });
+
+    state.update(cx, |s, cx| {
+        s.last_auth_error = None;
+        s.sign_in_task = Some(task);
+        cx.notify();
+    });
+}
+
+fn do_sign_out(state: &gpui::WeakEntity<State>, cx: &mut App) -> Task<Result<()>> {
+    let weak_state = state.clone();
+    // Clear credentials and cancel in-flight work immediately so the UI
+    // reflects the sign-out right away.
+    weak_state
+        .update(cx, |s, cx| {
+            s.auth_generation += 1;
+            s.credentials = None;
+            s.sign_in_task = None;
+            s.refresh_task = None;
+            s.last_auth_error = None;
+            cx.notify();
+        })
+        .log_err();
+
+    cx.spawn(async move |cx| {
+        let credentials_provider =
+            weak_state.read_with(&*cx, |s, _| s.credentials_provider.clone())?;
+        credentials_provider
+            .delete_credentials(CREDENTIALS_KEY, &*cx)
+            .await
+            .context("Failed to delete ChatGPT subscription credentials from keychain")?;
+        anyhow::Ok(())
+    })
+}
+
+struct ConfigurationView {
+    state: Entity<State>,
+    http_client: Arc<dyn HttpClient>,
+}
+
+impl Render for ConfigurationView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let state = self.state.read(cx);
+
+        if state.is_authenticated() {
+            let label = state
+                .email()
+                .map(|e| format!("Signed in as {e}"))
+                .unwrap_or_else(|| "Signed in".to_string());
+
+            let weak_state = self.state.downgrade();
+            return v_flex()
+                .child(
+                    ConfiguredApiCard::new(SharedString::from(label))
+                        .button_label("Sign Out")
+                        .on_click(cx.listener(move |_this, _, _window, cx| {
+                            do_sign_out(&weak_state, cx).detach_and_log_err(cx);
+                        })),
+                )
+                .into_any_element();
+        }
+
+        if state.is_signing_in() {
+            return v_flex()
+                .child(Label::new("Signing in…").color(Color::Muted))
+                .into_any_element();
+        }
+
+        let last_auth_error = state.last_auth_error.clone();
+        let provider_state = self.state.clone();
+        let http_client = self.http_client.clone();
+
+        v_flex()
+            .gap_2()
+            .when_some(last_auth_error, |this, error| {
+                this.child(Label::new(error).color(Color::Error))
+            })
+            .child(Label::new(
+                "Sign in with your ChatGPT Plus or Pro subscription to use OpenAI models in Zed's agent.",
+            ))
+            .child(
+                Button::new("sign-in", "Sign in with ChatGPT")
+                    .on_click(move |_, _window, cx| {
+                        do_sign_in(&provider_state, &http_client, cx);
+                    }),
+            )
+            .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use http_client::FakeHttpClient;
+    use parking_lot::Mutex;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeCredentialsProvider {
+        storage: Mutex<Option<(String, Vec<u8>)>>,
+    }
+
+    impl FakeCredentialsProvider {
+        fn new() -> Self {
+            Self {
+                storage: Mutex::new(None),
+            }
+        }
+    }
+
+    impl CredentialsProvider for FakeCredentialsProvider {
+        fn read_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<(String, Vec<u8>)>>> + 'a>> {
+            Box::pin(async { Ok(self.storage.lock().clone()) })
+        }
+
+        fn write_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            username: &'a str,
+            password: &'a [u8],
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
+            self.storage
+                .lock()
+                .replace((username.to_string(), password.to_vec()));
+            Box::pin(async { Ok(()) })
+        }
+
+        fn delete_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
+            *self.storage.lock() = None;
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn make_expired_credentials() -> CodexCredentials {
+        CodexCredentials {
+            access_token: "old_access".to_string(),
+            refresh_token: "old_refresh".to_string(),
+            expires_at_ms: 0,
+            account_id: None,
+            email: None,
+        }
+    }
+
+    fn make_fresh_credentials() -> CodexCredentials {
+        CodexCredentials {
+            access_token: "fresh_access".to_string(),
+            refresh_token: "fresh_refresh".to_string(),
+            expires_at_ms: now_ms() + 3_600_000,
+            account_id: None,
+            email: None,
+        }
+    }
+
+    fn fake_token_response() -> String {
+        serde_json::json!({
+            "access_token": "fresh_access",
+            "refresh_token": "fresh_refresh",
+            "expires_in": 3600
+        })
+        .to_string()
+    }
+
+    #[gpui::test]
+    async fn test_concurrent_refresh_deduplicates(cx: &mut TestAppContext) {
+        let refresh_count = Arc::new(AtomicUsize::new(0));
+        let refresh_count_clone = refresh_count.clone();
+
+        let http_client = FakeHttpClient::create(move |_request| {
+            let refresh_count = refresh_count_clone.clone();
+            async move {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                let body = fake_token_response();
+                Ok(http_client::Response::builder()
+                    .status(200)
+                    .body(http_client::AsyncBody::from(body))?)
+            }
+        });
+
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_expired_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: Arc::new(FakeCredentialsProvider::new()),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        // Spawn two concurrent refresh attempts.
+        let weak1 = weak_state.clone();
+        let http1 = http.clone();
+        let task1 =
+            cx.spawn(async move |mut cx| get_fresh_credentials(&weak1, &http1, &mut cx).await);
+
+        let weak2 = weak_state.clone();
+        let http2 = http.clone();
+        let task2 =
+            cx.spawn(async move |mut cx| get_fresh_credentials(&weak2, &http2, &mut cx).await);
+
+        // Drive both to completion.
+        cx.run_until_parked();
+        let result1 = task1.await;
+        let result2 = task2.await;
+
+        assert!(result1.is_ok(), "first refresh should succeed");
+        assert!(result2.is_ok(), "second refresh should succeed");
+        assert_eq!(result1.unwrap().access_token, "fresh_access");
+        assert_eq!(result2.unwrap().access_token, "fresh_access");
+        assert_eq!(
+            refresh_count.load(Ordering::SeqCst),
+            1,
+            "refresh_token should only be called once despite two concurrent callers"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_fresh_credentials_skip_refresh(cx: &mut TestAppContext) {
+        let refresh_count = Arc::new(AtomicUsize::new(0));
+        let refresh_count_clone = refresh_count.clone();
+
+        let http_client = FakeHttpClient::create(move |_request| {
+            let refresh_count = refresh_count_clone.clone();
+            async move {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                let body = fake_token_response();
+                Ok(http_client::Response::builder()
+                    .status(200)
+                    .body(http_client::AsyncBody::from(body))?)
+            }
+        });
+
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_fresh_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: Arc::new(FakeCredentialsProvider::new()),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        let weak = weak_state.clone();
+        let http_clone = http.clone();
+        let result = cx
+            .spawn(async move |mut cx| get_fresh_credentials(&weak, &http_clone, &mut cx).await)
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().access_token, "fresh_access");
+        assert_eq!(
+            refresh_count.load(Ordering::SeqCst),
+            0,
+            "no refresh should happen when credentials are fresh"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_no_credentials_returns_no_api_key(cx: &mut TestAppContext) {
+        let http_client = FakeHttpClient::create(|_| async {
+            Ok(http_client::Response::builder()
+                .status(200)
+                .body(http_client::AsyncBody::default())?)
+        });
+
+        let state = cx.new(|_cx| State {
+            credentials: None,
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: Arc::new(FakeCredentialsProvider::new()),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        let weak = weak_state.clone();
+        let http_clone = http.clone();
+        let result = cx
+            .spawn(async move |mut cx| get_fresh_credentials(&weak, &http_clone, &mut cx).await)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(LanguageModelCompletionError::NoApiKey { .. })
+        ));
+    }
+
+    #[gpui::test]
+    async fn test_fatal_refresh_clears_auth_state(cx: &mut TestAppContext) {
+        let http_client = FakeHttpClient::create(move |_request| async move {
+            Ok(http_client::Response::builder()
+                .status(401)
+                .body(http_client::AsyncBody::from(r#"{"error":"invalid_grant"}"#))?)
+        });
+
+        let creds_provider = Arc::new(FakeCredentialsProvider::new());
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_expired_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: creds_provider.clone(),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        let weak = weak_state.clone();
+        let http_clone = http.clone();
+        let result = cx
+            .spawn(async move |mut cx| get_fresh_credentials(&weak, &http_clone, &mut cx).await)
+            .await;
+
+        cx.run_until_parked();
+
+        assert!(result.is_err(), "fatal refresh should return an error");
+        cx.read(|cx| {
+            let s = state.read(cx);
+            assert!(
+                s.credentials.is_none(),
+                "credentials should be cleared on fatal refresh failure"
+            );
+            assert!(
+                s.last_auth_error.is_some(),
+                "last_auth_error should be set on fatal refresh failure"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_transient_refresh_keeps_credentials(cx: &mut TestAppContext) {
+        let http_client = FakeHttpClient::create(move |_request| async move {
+            Ok(http_client::Response::builder()
+                .status(500)
+                .body(http_client::AsyncBody::from("Internal Server Error"))?)
+        });
+
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_expired_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: Arc::new(FakeCredentialsProvider::new()),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        let weak = weak_state.clone();
+        let http_clone = http.clone();
+        let result = cx
+            .spawn(async move |mut cx| get_fresh_credentials(&weak, &http_clone, &mut cx).await)
+            .await;
+
+        cx.run_until_parked();
+
+        assert!(result.is_err(), "transient refresh should return an error");
+        cx.read(|cx| {
+            let s = state.read(cx);
+            assert!(
+                s.credentials.is_some(),
+                "credentials should be kept on transient refresh failure"
+            );
+            assert!(
+                s.last_auth_error.is_none(),
+                "last_auth_error should not be set on transient refresh failure"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_sign_out_during_refresh_discards_result(cx: &mut TestAppContext) {
+        let (gate_tx, gate_rx) = futures::channel::oneshot::channel::<()>();
+        let gate_rx = Arc::new(Mutex::new(Some(gate_rx)));
+        let gate_rx_clone = gate_rx.clone();
+
+        let http_client = FakeHttpClient::create(move |_request| {
+            let gate_rx = gate_rx_clone.clone();
+            async move {
+                // Wait until the gate is opened, simulating a slow network.
+                let rx = gate_rx.lock().take();
+                if let Some(rx) = rx {
+                    let _ = rx.await;
+                }
+                let body = fake_token_response();
+                Ok(http_client::Response::builder()
+                    .status(200)
+                    .body(http_client::AsyncBody::from(body))?)
+            }
+        });
+
+        let creds_provider = Arc::new(FakeCredentialsProvider::new());
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_expired_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: creds_provider.clone(),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let http: Arc<dyn HttpClient> = http_client;
+
+        // Start a refresh
+        let weak = weak_state.clone();
+        let http_clone = http.clone();
+        let refresh_task =
+            cx.spawn(async move |mut cx| get_fresh_credentials(&weak, &http_clone, &mut cx).await);
+
+        cx.run_until_parked();
+
+        // Sign out while the refresh is in-flight
+        cx.update(|cx| {
+            do_sign_out(&weak_state, cx).detach();
+        });
+        cx.run_until_parked();
+
+        // Now let the refresh respond by opening the gate
+        let _ = gate_tx.send(());
+        cx.run_until_parked();
+
+        let result = refresh_task.await;
+        assert!(result.is_err(), "refresh should fail after sign-out");
+
+        cx.read(|cx| {
+            let s = state.read(cx);
+            assert!(
+                s.credentials.is_none(),
+                "sign-out should have cleared credentials"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_sign_out_completes_fully(cx: &mut TestAppContext) {
+        let creds_provider = Arc::new(FakeCredentialsProvider::new());
+        // Pre-populate the credential store
+        creds_provider
+            .storage
+            .lock()
+            .replace(("Bearer".to_string(), b"some-creds".to_vec()));
+
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_fresh_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: creds_provider.clone(),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let weak_state = cx.read(|_cx| state.downgrade());
+        let sign_out_task = cx.update(|cx| do_sign_out(&weak_state, cx));
+
+        cx.run_until_parked();
+        sign_out_task.await.expect("sign-out should succeed");
+
+        assert!(
+            creds_provider.storage.lock().is_none(),
+            "credential store should be empty after sign-out"
+        );
+        cx.read(|cx| {
+            assert!(
+                !state.read(cx).is_authenticated(),
+                "state should show not authenticated"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_authenticate_awaits_initial_load(cx: &mut TestAppContext) {
+        let creds = make_fresh_credentials();
+        let creds_json = serde_json::to_vec(&creds).unwrap();
+        let creds_provider = Arc::new(FakeCredentialsProvider::new());
+        creds_provider
+            .storage
+            .lock()
+            .replace(("Bearer".to_string(), creds_json));
+
+        let http_client = FakeHttpClient::create(|_| async {
+            Ok(http_client::Response::builder()
+                .status(200)
+                .body(http_client::AsyncBody::default())?)
+        });
+
+        let provider =
+            cx.update(|cx| OpenAiSubscribedProvider::new(http_client, creds_provider, cx));
+
+        // Before load completes, authenticate should still await the load.
+        let auth_task = cx.update(|cx| provider.authenticate(cx));
+
+        // Drive the load to completion.
+        cx.run_until_parked();
+
+        let result = auth_task.await;
+        assert!(
+            result.is_ok(),
+            "authenticate should succeed after load completes with valid credentials"
+        );
+    }
+}

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -7,9 +7,9 @@ use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use language_model::{
     AuthenticateError, IconOrSvg, LanguageModel, LanguageModelCompletionError,
-    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
-    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
-    LanguageModelRequest, LanguageModelToolChoice, RateLimiter,
+    LanguageModelCompletionEvent, LanguageModelEffortLevel, LanguageModelId, LanguageModelName,
+    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
+    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice, RateLimiter,
 };
 use open_ai::{ReasoningEffort, responses::stream_response};
 use rand::RngCore as _;
@@ -323,15 +323,19 @@ impl ChatGptModel {
         true
     }
 
-    fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+    fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
         // Codex bundled models all default to Medium reasoning effort.
         Some(ReasoningEffort::Medium)
     }
 
-    fn supports_none_reasoning_effort(&self) -> bool {
-        // The Codex backend's supported_reasoning_levels for every model in
-        // this list is low/medium/high/xhigh -- sending `none` is rejected.
-        false
+    fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
+        // The Codex backend's supported_reasoning_levels for every model in this list is low/medium/high/xhigh
+        &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ]
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {
@@ -385,7 +389,32 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
     }
 
     fn supports_thinking(&self) -> bool {
-        self.model.reasoning_effort().is_some()
+        true
+    }
+
+    fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
+        let default_effort = self.model.default_reasoning_effort();
+        self.model
+            .supported_reasoning_efforts()
+            .iter()
+            .copied()
+            .filter_map(|effort| {
+                let (name, value) = match effort {
+                    ReasoningEffort::None => return None,
+                    ReasoningEffort::Minimal => ("Minimal", "minimal"),
+                    ReasoningEffort::Low => ("Low", "low"),
+                    ReasoningEffort::Medium => ("Medium", "medium"),
+                    ReasoningEffort::High => ("High", "high"),
+                    ReasoningEffort::XHigh => ("Extra High", "xhigh"),
+                };
+
+                Some(LanguageModelEffortLevel {
+                    name: name.into(),
+                    value: value.into(),
+                    is_default: Some(effort) == default_effort,
+                })
+            })
+            .collect()
     }
 
     fn telemetry_id(&self) -> String {
@@ -423,8 +452,10 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
             /*max_output_tokens*/ None,
-            self.model.reasoning_effort(),
-            self.model.supports_none_reasoning_effort(),
+            self.model.default_reasoning_effort(),
+            self.model
+                .supported_reasoning_efforts()
+                .contains(&ReasoningEffort::None),
         );
         responses_request.store = Some(false);
 

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -475,9 +475,7 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
             }
             true
         });
-        if !instructions.is_empty() {
-            responses_request.instructions = Some(instructions.join("\n\n"));
-        }
+        responses_request.instructions = Some(instructions.join("\n\n"));
 
         let state = self.state.downgrade();
         let http_client = self.http_client.clone();

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -479,6 +479,7 @@ impl OpenCodeLanguageModel {
                 &api_url,
                 &api_key,
                 request,
+                vec![],
             );
             let response = request.await?;
             Ok(response)

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -32,6 +32,7 @@ use crate::provider::open_ai::{
 
 fn normalize_reasoning_effort(effort: &str) -> Option<ReasoningEffort> {
     match effort.trim().to_ascii_lowercase().as_str() {
+        "none" => Some(ReasoningEffort::None),
         "minimal" => Some(ReasoningEffort::Minimal),
         "low" => Some(ReasoningEffort::Low),
         "medium" => Some(ReasoningEffort::Medium),
@@ -43,6 +44,7 @@ fn normalize_reasoning_effort(effort: &str) -> Option<ReasoningEffort> {
 
 fn reasoning_effort_display(effort: ReasoningEffort) -> (&'static str, &'static str) {
     match effort {
+        ReasoningEffort::None => ("None", "none"),
         ReasoningEffort::Minimal => ("Minimal", "minimal"),
         ReasoningEffort::Low => ("Low", "low"),
         ReasoningEffort::Medium => ("Medium", "medium"),
@@ -549,13 +551,17 @@ impl LanguageModel for OpenCodeLanguageModel {
     fn supports_thinking(&self) -> bool {
         self.model
             .supported_reasoning_effort_levels()
-            .is_some_and(|levels| !levels.is_empty())
+            .is_some_and(|levels| levels.iter().any(|effort| *effort != ReasoningEffort::None))
     }
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
         self.model
             .supported_reasoning_effort_levels()
             .map(|levels| {
+                let levels = levels
+                    .into_iter()
+                    .filter(|effort| *effort != ReasoningEffort::None)
+                    .collect::<Vec<_>>();
                 if levels.is_empty() {
                     return Vec::new();
                 }
@@ -675,21 +681,18 @@ impl LanguageModel for OpenCodeLanguageModel {
                 .boxed()
             }
             ApiProtocol::OpenAiResponses => {
-                let reasoning_effort = if request.thinking_allowed {
-                    request
-                        .thinking_effort
-                        .as_deref()
-                        .and_then(normalize_reasoning_effort)
-                } else {
-                    None
-                };
+                let supports_none_reasoning_effort = self
+                    .model
+                    .supported_reasoning_effort_levels()
+                    .is_some_and(|levels| levels.contains(&ReasoningEffort::None));
                 let response_request = into_open_ai_response(
                     request,
                     self.model.id(),
                     false,
                     false,
                     self.model.max_output_tokens(),
-                    reasoning_effort,
+                    None,
+                    supports_none_reasoning_effort,
                 );
                 let stream = self.stream_openai_response(response_request, http_client, cx);
                 async move {

--- a/crates/language_models_cloud/src/language_models_cloud.rs
+++ b/crates/language_models_cloud/src/language_models_cloud.rs
@@ -460,7 +460,13 @@ impl<TP: CloudLlmTokenProvider + 'static> LanguageModel for CloudLanguageModel<T
                 let effort = request
                     .thinking_effort
                     .as_ref()
-                    .and_then(|effort| open_ai::ReasoningEffort::from_str(effort).ok());
+                    .and_then(|effort| open_ai::ReasoningEffort::from_str(effort).ok())
+                    .filter(|effort| *effort != open_ai::ReasoningEffort::None);
+                let supports_none_reasoning_effort =
+                    self.model.supported_effort_levels.iter().any(|effort| {
+                        open_ai::ReasoningEffort::from_str(&effort.value)
+                            .is_ok_and(|effort| effort == open_ai::ReasoningEffort::None)
+                    });
 
                 let mut request = into_open_ai_response(
                     request,
@@ -469,6 +475,7 @@ impl<TP: CloudLlmTokenProvider + 'static> LanguageModel for CloudLanguageModel<T
                     true,
                     None,
                     None,
+                    supports_none_reasoning_effort,
                 );
 
                 if enable_thinking && let Some(effort) = effort {

--- a/crates/oauth_callback_server/Cargo.toml
+++ b/crates/oauth_callback_server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "oauth_callback_server"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+license = "Apache-2.0"
+description = "Loopback OAuth 2.0 callback server and shared HTML response page for Zed sign-in flows"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/oauth_callback_server.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+futures.workspace = true
+log.workspace = true
+tiny_http.workspace = true
+url.workspace = true

--- a/crates/oauth_callback_server/LICENSE-APACHE
+++ b/crates/oauth_callback_server/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/oauth_callback_server/src/oauth_callback_server.rs
+++ b/crates/oauth_callback_server/src/oauth_callback_server.rs
@@ -1,0 +1,493 @@
+//! Loopback OAuth 2.0 callback server and shared HTML response page.
+//!
+//! Used by Zed's OAuth-based sign-in flows (e.g. MCP servers, ChatGPT
+//! Subscription) to receive the authorization code redirect from the user's
+//! browser. The HTML response page rendered to the browser is kept alongside
+//! the server so all OAuth callback presentation lives in one place.
+
+/// Generate a styled HTML page for OAuth callback responses.
+///
+/// Returns a complete HTML document (no HTTP headers) with a centered card
+/// layout styled to match Zed's dark theme. The `title` is rendered as a
+/// heading and `message` as body text below it.
+///
+/// When `is_error` is true, a red X icon is shown instead of the green
+/// checkmark.
+pub fn oauth_callback_page(title: &str, message: &str, is_error: bool) -> String {
+    let title = html_escape(title);
+    let message = html_escape(message);
+    let (icon_bg, icon_svg) = if is_error {
+        (
+            "#f38ba8",
+            r#"<svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>"#,
+        )
+    } else {
+        (
+            "#a6e3a1",
+            r#"<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>"#,
+        )
+    };
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title} — Zed</title>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: #1e1e2e;
+    color: #cdd6f4;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 1rem;
+  }}
+  .card {{
+    background: #313244;
+    border-radius: 12px;
+    padding: 2.5rem;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+  }}
+  .icon {{
+    width: 48px;
+    height: 48px;
+    margin: 0 auto 1.5rem;
+    background: {icon_bg};
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }}
+  .icon svg {{
+    width: 24px;
+    height: 24px;
+    stroke: #1e1e2e;
+    stroke-width: 3;
+    fill: none;
+  }}
+  h1 {{
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: #cdd6f4;
+  }}
+  p {{
+    font-size: 0.925rem;
+    line-height: 1.5;
+    color: #a6adc8;
+  }}
+  .brand {{
+    margin-top: 1.5rem;
+    font-size: 0.8rem;
+    color: #585b70;
+    letter-spacing: 0.05em;
+  }}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">
+    {icon_svg}
+  </div>
+  <h1>{title}</h1>
+  <p>{message}</p>
+  <div class="brand">Zed</div>
+</div>
+</body>
+</html>"#,
+        title = title,
+        message = message,
+        icon_bg = icon_bg,
+        icon_svg = icon_svg,
+    )
+}
+
+fn html_escape(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&#x27;"),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod server {
+    use super::oauth_callback_page;
+    use anyhow::{Context as _, Result, anyhow};
+    use std::str::FromStr;
+    use std::time::Duration;
+    use url::Url;
+
+    /// Parsed OAuth callback parameters from the authorization server redirect.
+    pub struct OAuthCallbackParams {
+        pub code: String,
+        pub state: String,
+    }
+
+    /// Configuration for the loopback OAuth callback server.
+    ///
+    /// OAuth servers compare `redirect_uri` against a per-client allow-list using
+    /// exact string matching (RFC 6749 §3.1.2), so the `host`, `preferred_port`,
+    /// and `path` here must match what's registered for the OAuth client_id.
+    #[derive(Clone, Copy)]
+    pub struct OAuthCallbackServerConfig {
+        /// Host portion of the redirect URI (typically `127.0.0.1` or `localhost`).
+        pub host: &'static str,
+        /// Preferred port. Use `0` for an OS-assigned ephemeral port.
+        pub preferred_port: u16,
+        /// Optional fallback port if `preferred_port` is unavailable. Only used
+        /// when `preferred_port` is non-zero.
+        pub fallback_port: Option<u16>,
+        /// Callback path on the redirect URI (e.g. `/callback`, `/auth/callback`).
+        pub path: &'static str,
+    }
+
+    impl Default for OAuthCallbackServerConfig {
+        fn default() -> Self {
+            Self {
+                host: "127.0.0.1",
+                preferred_port: 0,
+                fallback_port: None,
+                path: "/callback",
+            }
+        }
+    }
+
+    impl OAuthCallbackParams {
+        /// Parse the query string from a callback URL like
+        /// `http://127.0.0.1:<port>/callback?code=...&state=...`.
+        pub fn parse_query(query: &str) -> Result<Self> {
+            let mut code: Option<String> = None;
+            let mut state: Option<String> = None;
+            let mut error: Option<String> = None;
+            let mut error_description: Option<String> = None;
+
+            for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+                match key.as_ref() {
+                    "code" => {
+                        if !value.is_empty() {
+                            code = Some(value.into_owned());
+                        }
+                    }
+                    "state" => {
+                        if !value.is_empty() {
+                            state = Some(value.into_owned());
+                        }
+                    }
+                    "error" => {
+                        if !value.is_empty() {
+                            error = Some(value.into_owned());
+                        }
+                    }
+                    "error_description" => {
+                        if !value.is_empty() {
+                            error_description = Some(value.into_owned());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if let Some(error_code) = error {
+                anyhow::bail!(
+                    "OAuth authorization failed: {} ({})",
+                    error_code,
+                    error_description.as_deref().unwrap_or("no description")
+                );
+            }
+
+            let code = code.ok_or_else(|| anyhow!("missing 'code' parameter in OAuth callback"))?;
+            let state =
+                state.ok_or_else(|| anyhow!("missing 'state' parameter in OAuth callback"))?;
+
+            Ok(Self { code, state })
+        }
+    }
+
+    /// How long to wait for the browser to complete the OAuth flow before giving
+    /// up and releasing the loopback port.
+    const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(2 * 60);
+
+    /// Start a loopback HTTP server to receive the OAuth authorization callback.
+    ///
+    /// Binds to an ephemeral loopback port. Returns `(redirect_uri, callback_future)`.
+    /// The caller should use the redirect URI in the authorization request, open
+    /// the browser, then await the future to receive the callback.
+    pub fn start_oauth_callback_server() -> Result<(
+        String,
+        futures::channel::oneshot::Receiver<Result<OAuthCallbackParams>>,
+    )> {
+        start_oauth_callback_server_with_config(OAuthCallbackServerConfig::default())
+    }
+
+    /// Start a loopback HTTP server with custom host/port/path.
+    ///
+    /// Use this when the OAuth client requires a specific redirect URI that the
+    /// default ephemeral-port `http://127.0.0.1:<port>/callback` doesn't match.
+    pub fn start_oauth_callback_server_with_config(
+        config: OAuthCallbackServerConfig,
+    ) -> Result<(
+        String,
+        futures::channel::oneshot::Receiver<Result<OAuthCallbackParams>>,
+    )> {
+        let server = bind_callback_server(&config)?;
+        let port = server
+            .server_addr()
+            .to_ip()
+            .ok_or_else(|| anyhow!("server not bound to a TCP address"))?
+            .port();
+
+        let redirect_uri = format!("http://{}:{}{}", config.host, port, config.path);
+        let expected_path = config.path;
+
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + OAUTH_CALLBACK_TIMEOUT;
+
+            loop {
+                if tx.is_canceled() {
+                    return;
+                }
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    return;
+                }
+
+                let timeout = remaining.min(Duration::from_millis(500));
+                let Some(request) = (match server.recv_timeout(timeout) {
+                    Ok(req) => req,
+                    Err(_) => {
+                        let _ = tx.send(Err(anyhow!("OAuth callback server I/O error")));
+                        return;
+                    }
+                }) else {
+                    continue;
+                };
+
+                let raw_url = request.url().to_string();
+                let raw_path = raw_url.split('?').next().unwrap_or(&raw_url);
+                if raw_path == CANCEL_PATH {
+                    let response = tiny_http::Response::from_string("Cancelled")
+                        .with_status_code(200)
+                        .with_header(
+                            tiny_http::Header::from_str("Content-Type: text/plain")
+                                .expect("failed to construct response header"),
+                        )
+                        .with_header(
+                            tiny_http::Header::from_str("Connection: close")
+                                .expect("failed to construct response header"),
+                        );
+                    if let Err(err) = request.respond(response) {
+                        log::error!("Failed to send OAuth cancel response: {}", err);
+                    }
+                    let _ = tx.send(Err(anyhow!(
+                        "OAuth callback server was cancelled by another sign-in attempt"
+                    )));
+                    return;
+                }
+
+                let result = handle_oauth_callback_request(&request, expected_path);
+
+                let (status_code, body) = match &result {
+                    Ok(_) => (
+                        200,
+                        oauth_callback_page(
+                            "Authorization Successful",
+                            "You can close this tab and return to Zed.",
+                            false,
+                        ),
+                    ),
+                    Err(err) => {
+                        log::error!("OAuth callback error: {}", err);
+                        (
+                            400,
+                            oauth_callback_page(
+                                "Authorization Failed",
+                                "Something went wrong. Please try again from Zed.",
+                                true,
+                            ),
+                        )
+                    }
+                };
+
+                let response = tiny_http::Response::from_string(body)
+                    .with_status_code(status_code)
+                    .with_header(
+                        tiny_http::Header::from_str("Content-Type: text/html")
+                            .expect("failed to construct response header"),
+                    )
+                    .with_header(
+                        tiny_http::Header::from_str("Keep-Alive: timeout=0,max=0")
+                            .expect("failed to construct response header"),
+                    );
+                if let Err(err) = request.respond(response) {
+                    log::error!("Failed to send OAuth callback response: {}", err);
+                }
+
+                let _ = tx.send(result);
+                return;
+            }
+        });
+
+        Ok((redirect_uri, rx))
+    }
+
+    fn handle_oauth_callback_request(
+        request: &tiny_http::Request,
+        expected_path: &str,
+    ) -> Result<OAuthCallbackParams> {
+        let url = Url::parse(&format!("http://localhost{}", request.url()))
+            .context("malformed callback request URL")?;
+
+        if url.path() != expected_path {
+            anyhow::bail!("unexpected path in OAuth callback: {}", url.path());
+        }
+
+        let query = url
+            .query()
+            .ok_or_else(|| anyhow!("OAuth callback has no query string"))?;
+        OAuthCallbackParams::parse_query(query)
+    }
+
+    /// Callback path reserved for evicting a previously-running OAuth callback
+    /// server bound to the same port. Always handled, regardless of `config.path`.
+    const CANCEL_PATH: &str = "/cancel";
+
+    const BIND_MAX_ATTEMPTS: u32 = 10;
+    const BIND_RETRY_DELAY: Duration = Duration::from_millis(200);
+    const CANCEL_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+    fn bind_callback_server(config: &OAuthCallbackServerConfig) -> Result<tiny_http::Server> {
+        // Ephemeral ports always succeed; skip the cancel-retry dance entirely.
+        if config.preferred_port == 0 {
+            let addr = format!("{}:0", config.host);
+            return tiny_http::Server::http(&addr).map_err(|err| {
+                anyhow!(err).context(format!(
+                    "Failed to bind loopback listener for OAuth callback on {addr}"
+                ))
+            });
+        }
+
+        match try_bind_with_cancel(config.host, config.preferred_port) {
+            Ok(server) => Ok(server),
+            Err(primary_err) => {
+                let Some(fallback_port) = config.fallback_port else {
+                    return Err(primary_err.context(format!(
+                        "Failed to bind loopback listener for OAuth callback on {}:{}",
+                        config.host, config.preferred_port,
+                    )));
+                };
+                log::warn!(
+                    "OAuth callback port {}:{} unavailable; falling back to port {}",
+                    config.host,
+                    config.preferred_port,
+                    fallback_port,
+                );
+                try_bind_with_cancel(config.host, fallback_port).map_err(|fallback_err| {
+                    fallback_err.context(format!(
+                        "Failed to bind loopback listener for OAuth callback on {}:{} or {}:{}",
+                        config.host, config.preferred_port, config.host, fallback_port,
+                    ))
+                })
+            }
+        }
+    }
+
+    /// Attempts to bind to a fixed `host:port`. On `AddrInUse`, sends a single
+    /// `GET /cancel` to the existing listener (to evict a previous OAuth flow
+    /// from this or a compatible client) and retries.
+    fn try_bind_with_cancel(host: &'static str, port: u16) -> Result<tiny_http::Server> {
+        let addr = format!("{host}:{port}");
+        let mut cancel_attempted = false;
+        let mut last_err: Option<anyhow::Error> = None;
+
+        for _ in 0..BIND_MAX_ATTEMPTS {
+            match tiny_http::Server::http(&addr) {
+                Ok(server) => return Ok(server),
+                Err(err) => {
+                    let is_addr_in_use = err
+                        .downcast_ref::<std::io::Error>()
+                        .map(|io_err| io_err.kind() == std::io::ErrorKind::AddrInUse)
+                        .unwrap_or(false);
+
+                    if !is_addr_in_use {
+                        return Err(anyhow!(err).context(format!(
+                            "Failed to bind loopback listener for OAuth callback on {addr}"
+                        )));
+                    }
+
+                    if !cancel_attempted {
+                        cancel_attempted = true;
+                        if let Err(cancel_err) = send_cancel_request(host, port) {
+                            log::warn!(
+                                "Failed to cancel previous OAuth callback server on {addr}: {cancel_err}"
+                            );
+                        }
+                    }
+
+                    last_err = Some(anyhow!(err));
+                    std::thread::sleep(BIND_RETRY_DELAY);
+                }
+            }
+        }
+
+        Err(last_err
+            .unwrap_or_else(|| anyhow!("unknown bind error"))
+            .context(format!(
+                "OAuth callback port {addr} remained in use after {BIND_MAX_ATTEMPTS} attempts"
+            )))
+    }
+
+    /// Sends `GET /cancel` to a listener on `host:port`, asking it to shut down.
+    ///
+    /// Best-effort: errors here are surfaced to the caller for logging but do
+    /// not block the subsequent rebind attempt.
+    fn send_cancel_request(host: &str, port: u16) -> std::io::Result<()> {
+        use std::io::{Read as _, Write as _};
+        use std::net::{TcpStream, ToSocketAddrs as _};
+
+        let addr = format!("{host}:{port}")
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("could not resolve {host}:{port}"),
+                )
+            })?;
+        let mut stream = TcpStream::connect_timeout(&addr, CANCEL_REQUEST_TIMEOUT)?;
+        stream.set_read_timeout(Some(CANCEL_REQUEST_TIMEOUT))?;
+        stream.set_write_timeout(Some(CANCEL_REQUEST_TIMEOUT))?;
+
+        stream.write_all(b"GET /cancel HTTP/1.1\r\n")?;
+        stream.write_all(format!("Host: {host}:{port}\r\n").as_bytes())?;
+        stream.write_all(b"Connection: close\r\n\r\n")?;
+
+        // Drain the response so the server can close cleanly. We don't care
+        // about the body; errors here are harmless.
+        let mut buf = [0u8; 64];
+        let _ = stream.read(&mut buf);
+        Ok(())
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub use server::{
+    OAuthCallbackParams, OAuthCallbackServerConfig, start_oauth_callback_server,
+    start_oauth_callback_server_with_config,
+};

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -259,8 +259,9 @@ pub fn into_open_ai_response(
 
     ResponseRequest {
         model: model_id.into(),
+        instructions: None,
         input: input_items,
-        store: false,
+        store: Some(false),
         include,
         stream,
         temperature,

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -190,8 +190,8 @@ pub fn into_open_ai_response(
         tool_choice,
         stop: _,
         temperature,
-        thinking_allowed: _,
-        thinking_effort: _,
+        thinking_allowed,
+        thinking_effort,
         speed: _,
     } = request;
 
@@ -233,10 +233,18 @@ pub fn into_open_ai_response(
         } else {
             None
         },
-        reasoning: reasoning_effort.map(|effort| crate::responses::ReasoningConfig {
-            effort,
-            summary: Some(crate::responses::ReasoningSummaryMode::Auto),
-        }),
+        reasoning: if thinking_allowed {
+            thinking_effort
+                .as_deref()
+                .and_then(|effort| effort.parse::<ReasoningEffort>().ok())
+                .or(reasoning_effort)
+                .map(|effort| crate::responses::ReasoningConfig {
+                    effort,
+                    summary: Some(crate::responses::ReasoningSummaryMode::Auto),
+                })
+        } else {
+            None
+        },
     }
 }
 
@@ -1000,8 +1008,8 @@ mod tests {
             tool_choice: Some(LanguageModelToolChoice::Any),
             stop: vec!["<STOP>".into()],
             temperature: None,
-            thinking_allowed: false,
-            thinking_effort: None,
+            thinking_allowed: true,
+            thinking_effort: Some("high".into()),
             speed: None,
         };
 
@@ -1065,10 +1073,44 @@ mod tests {
                 }
             ],
             "prompt_cache_key": "thread-123",
-            "reasoning": { "effort": "low", "summary": "auto" }
+            "reasoning": { "effort": "high", "summary": "auto" }
         });
 
         assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn into_open_ai_response_omits_reasoning_when_thinking_is_disabled() {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".into())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: Some("high".into()),
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Medium),
+        );
+
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert_eq!(serialized.get("reasoning"), None);
     }
 
     #[test]

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -12,15 +12,20 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::responses::{
-    Request as ResponseRequest, ResponseFunctionCallItem, ResponseFunctionCallOutputContent,
-    ResponseFunctionCallOutputItem, ResponseInputContent, ResponseInputItem, ResponseMessageItem,
-    ResponseOutputItem, ResponseSummary as ResponsesSummary, ResponseUsage as ResponsesUsage,
-    StreamEvent as ResponsesStreamEvent,
+    Request as ResponseRequest, ResponseError, ResponseFunctionCallItem,
+    ResponseFunctionCallOutputContent, ResponseFunctionCallOutputItem, ResponseIncludable,
+    ResponseInputContent, ResponseInputItem, ResponseMessageItem, ResponseOutputItem,
+    ResponseOutputMessage, ResponseReasoningInputItem, ResponseReasoningItem,
+    ResponseReasoningSummaryPart, ResponseSummary as ResponsesSummary,
+    ResponseUsage as ResponsesUsage, StreamEvent as ResponsesStreamEvent,
 };
 use crate::{
     FunctionContent, FunctionDefinition, ImageUrl, MessagePart, ReasoningEffort,
     ResponseStreamEvent, ToolCall, ToolCallContent,
 };
+
+const RESPONSE_MESSAGE_PHASE_COMMENTARY: &str = "commentary";
+const RESPONSE_MESSAGE_PHASE_FINAL_ANSWER: &str = "final_answer";
 
 pub fn into_open_ai(
     request: LanguageModelRequest,
@@ -177,7 +182,8 @@ pub fn into_open_ai_response(
     supports_parallel_tool_calls: bool,
     supports_prompt_cache_key: bool,
     max_output_tokens: Option<u64>,
-    reasoning_effort: Option<ReasoningEffort>,
+    default_reasoning_effort: Option<ReasoningEffort>,
+    supports_none_reasoning_effort: bool,
 ) -> ResponseRequest {
     let stream = !model_id.starts_with("o1-");
 
@@ -196,8 +202,14 @@ pub fn into_open_ai_response(
     } = request;
 
     let mut input_items = Vec::new();
+    let mut replayed_reasoning_item_indexes = HashMap::default();
     for (index, message) in messages.into_iter().enumerate() {
-        append_message_to_response_items(message, index, &mut input_items);
+        append_message_to_response_items(
+            message,
+            index,
+            &mut replayed_reasoning_item_indexes,
+            &mut input_items,
+        );
     }
 
     let tools: Vec<_> = tools
@@ -210,9 +222,46 @@ pub fn into_open_ai_response(
         })
         .collect();
 
+    let default_reasoning_effort =
+        default_reasoning_effort.filter(|effort| *effort != ReasoningEffort::None);
+    let reasoning_effort = if thinking_allowed {
+        thinking_effort
+            .as_deref()
+            .and_then(|effort| effort.parse::<ReasoningEffort>().ok())
+            .filter(|effort| *effort != ReasoningEffort::None)
+            .or(default_reasoning_effort)
+    } else if supports_none_reasoning_effort {
+        Some(ReasoningEffort::None)
+    } else {
+        None
+    };
+
+    let reasoning = reasoning_effort.map(|effort| crate::responses::ReasoningConfig {
+        effort,
+        summary: if effort == ReasoningEffort::None {
+            None
+        } else {
+            Some(crate::responses::ReasoningSummaryMode::Auto)
+        },
+    });
+
+    let include = if reasoning
+        .as_ref()
+        .is_some_and(|reasoning| reasoning.effort != ReasoningEffort::None)
+        || input_items
+            .iter()
+            .any(|item| matches!(item, ResponseInputItem::Reasoning(_)))
+    {
+        vec![ResponseIncludable::ReasoningEncryptedContent]
+    } else {
+        Vec::new()
+    };
+
     ResponseRequest {
         model: model_id.into(),
         input: input_items,
+        store: false,
+        include,
         stream,
         temperature,
         top_p: None,
@@ -233,42 +282,55 @@ pub fn into_open_ai_response(
         } else {
             None
         },
-        reasoning: if thinking_allowed {
-            thinking_effort
-                .as_deref()
-                .and_then(|effort| effort.parse::<ReasoningEffort>().ok())
-                .or(reasoning_effort)
-                .map(|effort| crate::responses::ReasoningConfig {
-                    effort,
-                    summary: Some(crate::responses::ReasoningSummaryMode::Auto),
-                })
-        } else {
-            None
-        },
+        reasoning,
     }
 }
 
 fn append_message_to_response_items(
     message: LanguageModelRequestMessage,
     index: usize,
+    replayed_reasoning_item_indexes: &mut HashMap<String, usize>,
     input_items: &mut Vec<ResponseInputItem>,
 ) {
     let mut content_parts: Vec<ResponseInputContent> = Vec::new();
 
-    for content in message.content {
+    let LanguageModelRequestMessage {
+        role,
+        content,
+        reasoning_details,
+        ..
+    } = message;
+    let phase = if role == Role::Assistant {
+        response_message_phase_from_details(reasoning_details.as_ref())
+    } else {
+        None
+    };
+
+    if role == Role::Assistant {
+        append_reasoning_details_to_response_items(
+            reasoning_details.as_ref(),
+            replayed_reasoning_item_indexes,
+            input_items,
+        );
+    }
+
+    for content in content {
         match content {
             MessageContent::Text(text) => {
-                push_response_text_part(&message.role, text, &mut content_parts);
+                push_response_text_part(&role, text, &mut content_parts);
             }
-            MessageContent::Thinking { text, .. } => {
-                push_response_text_part(&message.role, text, &mut content_parts);
-            }
-            MessageContent::RedactedThinking(_) => {}
+            MessageContent::Thinking { .. } | MessageContent::RedactedThinking(_) => {}
             MessageContent::Image(image) => {
-                push_response_image_part(&message.role, image, &mut content_parts);
+                push_response_image_part(&role, image, &mut content_parts);
             }
             MessageContent::ToolUse(tool_use) => {
-                flush_response_parts(&message.role, index, &mut content_parts, input_items);
+                flush_response_parts(
+                    &role,
+                    index,
+                    phase.as_deref(),
+                    &mut content_parts,
+                    input_items,
+                );
                 let call_id = tool_use.id.to_string();
                 input_items.push(ResponseInputItem::FunctionCall(ResponseFunctionCallItem {
                     call_id,
@@ -277,7 +339,13 @@ fn append_message_to_response_items(
                 }));
             }
             MessageContent::ToolResult(tool_result) => {
-                flush_response_parts(&message.role, index, &mut content_parts, input_items);
+                flush_response_parts(
+                    &role,
+                    index,
+                    phase.as_deref(),
+                    &mut content_parts,
+                    input_items,
+                );
                 let output = match tool_result.content.as_slice() {
                     [LanguageModelToolResultContent::Text(text)] => {
                         ResponseFunctionCallOutputContent::Text(text.to_string())
@@ -312,7 +380,48 @@ fn append_message_to_response_items(
         }
     }
 
-    flush_response_parts(&message.role, index, &mut content_parts, input_items);
+    flush_response_parts(
+        &role,
+        index,
+        phase.as_deref(),
+        &mut content_parts,
+        input_items,
+    );
+}
+
+fn append_reasoning_details_to_response_items(
+    reasoning_details: Option<&serde_json::Value>,
+    replayed_reasoning_item_indexes: &mut HashMap<String, usize>,
+    input_items: &mut Vec<ResponseInputItem>,
+) {
+    let Some(reasoning_details) = reasoning_details else {
+        return;
+    };
+
+    let Some(metadata) = response_message_metadata_from_details(reasoning_details) else {
+        return;
+    };
+
+    for reasoning_item in metadata.reasoning_items {
+        push_replayed_reasoning_item(reasoning_item, replayed_reasoning_item_indexes, input_items);
+    }
+}
+
+fn push_replayed_reasoning_item(
+    reasoning_item: ResponseReasoningInputItem,
+    replayed_reasoning_item_indexes: &mut HashMap<String, usize>,
+    input_items: &mut Vec<ResponseInputItem>,
+) {
+    if let Some(id) = reasoning_item.id.as_ref() {
+        if let Some(index) = replayed_reasoning_item_indexes.get(id) {
+            input_items[*index] = ResponseInputItem::Reasoning(reasoning_item);
+            return;
+        }
+
+        replayed_reasoning_item_indexes.insert(id.clone(), input_items.len());
+    }
+
+    input_items.push(ResponseInputItem::Reasoning(reasoning_item));
 }
 
 fn push_response_text_part(
@@ -353,6 +462,7 @@ fn push_response_image_part(
 fn flush_response_parts(
     role: &Role,
     _index: usize,
+    phase: Option<&str>,
     parts: &mut Vec<ResponseInputContent>,
     input_items: &mut Vec<ResponseInputItem>,
 ) {
@@ -367,6 +477,10 @@ fn flush_response_parts(
             Role::System => crate::Role::System,
         },
         content: parts.clone(),
+        phase: match role {
+            Role::Assistant => phase.map(str::to_string),
+            Role::User | Role::System => None,
+        },
     });
 
     input_items.push(item);
@@ -551,6 +665,8 @@ struct RawToolCall {
 
 pub struct OpenAiResponseEventMapper {
     function_calls_by_item: HashMap<String, PendingResponseFunctionCall>,
+    reasoning_items: Vec<ResponseReasoningInputItem>,
+    current_message_phase: Option<String>,
     pending_stop_reason: Option<StopReason>,
 }
 
@@ -565,6 +681,8 @@ impl OpenAiResponseEventMapper {
     pub fn new() -> Self {
         Self {
             function_calls_by_item: HashMap::default(),
+            reasoning_items: Vec::new(),
+            current_message_phase: None,
             pending_stop_reason: None,
         }
     }
@@ -597,6 +715,7 @@ impl OpenAiResponseEventMapper {
                                 message_id: id.clone(),
                             }));
                         }
+                        events.extend(self.capture_message_phase(message));
                     }
                     ResponseOutputItem::FunctionCall(function_call) => {
                         if let Some(item_id) = function_call.id.clone() {
@@ -635,6 +754,11 @@ impl OpenAiResponseEventMapper {
                 } else {
                     vec![Ok(LanguageModelCompletionEvent::Text(delta))]
                 }
+            }
+            ResponsesStreamEvent::RefusalDelta { .. }
+            | ResponsesStreamEvent::RefusalDone { .. } => {
+                self.pending_stop_reason = Some(StopReason::Refusal);
+                Vec::new()
             }
             ResponsesStreamEvent::FunctionCallArgumentsDelta { item_id, delta, .. } => {
                 if let Some(entry) = self.function_calls_by_item.get_mut(&item_id) {
@@ -696,11 +820,11 @@ impl OpenAiResponseEventMapper {
             }
             ResponsesStreamEvent::Incomplete { response } => {
                 let reason = response
-                    .status_details
+                    .incomplete_details
                     .as_ref()
                     .and_then(|details| details.reason.as_deref());
-                let stop_reason = match reason {
-                    Some("max_output_tokens") => StopReason::MaxTokens,
+                let mut stop_reason = match reason {
+                    Some("max_tokens" | "max_output_tokens") => StopReason::MaxTokens,
                     Some("content_filter") => {
                         self.pending_stop_reason = Some(StopReason::Refusal);
                         StopReason::Refusal
@@ -712,6 +836,13 @@ impl OpenAiResponseEventMapper {
                 };
 
                 let mut events = Vec::new();
+                events.extend(self.capture_reasoning_items_from_output(&response.output));
+                if response_output_contains_refusal(&response.output)
+                    && !matches!(stop_reason, StopReason::MaxTokens)
+                {
+                    self.pending_stop_reason = Some(StopReason::Refusal);
+                    stop_reason = StopReason::Refusal;
+                }
                 if self.pending_stop_reason.is_none() {
                     events.extend(self.emit_tool_calls_from_output(&response.output));
                 }
@@ -724,17 +855,13 @@ impl OpenAiResponseEventMapper {
                 events
             }
             ResponsesStreamEvent::Failed { response } => {
-                let message = response
-                    .status_details
-                    .and_then(|details| details.error)
-                    .map(|error| error.to_string())
-                    .unwrap_or_else(|| "response failed".to_string());
+                let message = response_failure_message(&response);
                 vec![Err(LanguageModelCompletionError::Other(anyhow!(message)))]
             }
             ResponsesStreamEvent::Error { error }
             | ResponsesStreamEvent::GenericError { error } => {
                 vec![Err(LanguageModelCompletionError::Other(anyhow!(
-                    error.message
+                    response_error_message(&error)
                 )))]
             }
             ResponsesStreamEvent::ReasoningSummaryPartAdded { summary_index, .. } => {
@@ -747,8 +874,12 @@ impl OpenAiResponseEventMapper {
                     Vec::new()
                 }
             }
+            ResponsesStreamEvent::OutputItemDone { item, .. } => match item {
+                ResponseOutputItem::Reasoning(reasoning) => self.capture_reasoning_item(&reasoning),
+                ResponseOutputItem::Message(message) => self.capture_message_phase(&message),
+                ResponseOutputItem::FunctionCall(_) | ResponseOutputItem::Unknown => Vec::new(),
+            },
             ResponsesStreamEvent::OutputTextDone { .. }
-            | ResponsesStreamEvent::OutputItemDone { .. }
             | ResponsesStreamEvent::ContentPartAdded { .. }
             | ResponsesStreamEvent::ContentPartDone { .. }
             | ResponsesStreamEvent::ReasoningSummaryTextDone { .. }
@@ -765,6 +896,12 @@ impl OpenAiResponseEventMapper {
         default_reason: StopReason,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let mut events = Vec::new();
+
+        events.extend(self.capture_reasoning_items_from_output(&response.output));
+
+        if response_output_contains_refusal(&response.output) {
+            self.pending_stop_reason = Some(StopReason::Refusal);
+        }
 
         if self.pending_stop_reason.is_none() {
             events.extend(self.emit_tool_calls_from_output(&response.output));
@@ -828,23 +965,198 @@ impl OpenAiResponseEventMapper {
         }
         events
     }
+
+    fn capture_reasoning_items_from_output(
+        &mut self,
+        output: &[ResponseOutputItem],
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let mut events = Vec::new();
+        for item in output {
+            if let ResponseOutputItem::Reasoning(reasoning) = item {
+                events.extend(self.capture_reasoning_item(reasoning));
+            }
+        }
+        events
+    }
+
+    fn capture_message_phase(
+        &mut self,
+        message: &ResponseOutputMessage,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        self.current_message_phase = message
+            .phase
+            .as_deref()
+            .and_then(normalize_response_message_phase)
+            .map(str::to_string);
+
+        if self.current_message_phase.is_none() && self.reasoning_items.is_empty() {
+            return Vec::new();
+        }
+
+        self.emit_response_message_metadata()
+    }
+
+    fn capture_reasoning_item(
+        &mut self,
+        reasoning: &ResponseReasoningItem,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let reasoning_item = response_reasoning_input_item_from_output(reasoning);
+
+        if self.reasoning_items.contains(&reasoning_item) {
+            return Vec::new();
+        }
+
+        if let Some(id) = reasoning_item.id.as_ref()
+            && let Some(existing_reasoning_item) = self
+                .reasoning_items
+                .iter_mut()
+                .find(|existing_reasoning_item| existing_reasoning_item.id.as_ref() == Some(id))
+        {
+            *existing_reasoning_item = reasoning_item;
+        } else {
+            self.reasoning_items.push(reasoning_item);
+        }
+
+        self.emit_response_message_metadata()
+    }
+
+    fn emit_response_message_metadata(
+        &self,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let details = serde_json::to_value(ResponseMessageMetadata {
+            phase: self.current_message_phase.clone(),
+            reasoning_items: self.reasoning_items.clone(),
+        });
+
+        match details {
+            Ok(details) => vec![Ok(LanguageModelCompletionEvent::ReasoningDetails(details))],
+            Err(error) => vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))],
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ResponseMessageMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    reasoning_items: Vec<ResponseReasoningInputItem>,
+}
+
+fn response_message_metadata_from_details(
+    details: &serde_json::Value,
+) -> Option<ResponseMessageMetadata> {
+    serde_json::from_value::<ResponseMessageMetadata>(details.clone()).ok()
+}
+
+fn response_message_phase_from_details(details: Option<&serde_json::Value>) -> Option<String> {
+    let metadata = response_message_metadata_from_details(details?)?;
+    metadata
+        .phase
+        .as_deref()
+        .and_then(normalize_response_message_phase)
+        .map(str::to_string)
+}
+
+fn normalize_response_message_phase(phase: &str) -> Option<&'static str> {
+    match phase {
+        RESPONSE_MESSAGE_PHASE_COMMENTARY => Some(RESPONSE_MESSAGE_PHASE_COMMENTARY),
+        RESPONSE_MESSAGE_PHASE_FINAL_ANSWER => Some(RESPONSE_MESSAGE_PHASE_FINAL_ANSWER),
+        _ => None,
+    }
+}
+
+fn response_failure_message(response: &ResponsesSummary) -> String {
+    if let Some(error) = response.error.as_ref() {
+        return response_error_message(error);
+    }
+
+    response
+        .status
+        .as_deref()
+        .map(|status| format!("response.{status}"))
+        .unwrap_or_else(|| "response.failed".to_string())
+}
+
+fn response_error_message(error: &ResponseError) -> String {
+    let code = error.code.as_deref().filter(|code| !code.trim().is_empty());
+    let message = error.message.trim();
+
+    match (code, message.is_empty()) {
+        (Some(code), false) => format!("{code}: {message}"),
+        (Some(code), true) => code.to_string(),
+        (None, false) => message.to_string(),
+        (None, true) => "response error".to_string(),
+    }
+}
+
+fn response_output_contains_refusal(output: &[ResponseOutputItem]) -> bool {
+    output.iter().any(|item| {
+        if let ResponseOutputItem::Message(message) = item {
+            message.content.iter().any(response_content_is_refusal)
+        } else {
+            false
+        }
+    })
+}
+
+fn response_content_is_refusal(content: &serde_json::Value) -> bool {
+    let content_type = content
+        .get("type")
+        .and_then(|content_type| content_type.as_str());
+    let refusal = content
+        .get("refusal")
+        .and_then(|refusal| refusal.as_str())
+        .unwrap_or_default();
+
+    content_type == Some("refusal") || !refusal.is_empty()
 }
 
 fn token_usage_from_response_usage(usage: &ResponsesUsage) -> TokenUsage {
+    let cache_read_input_tokens = usage.input_tokens_details.cached_tokens;
+
     TokenUsage {
-        input_tokens: usage.input_tokens.unwrap_or_default(),
+        input_tokens: usage
+            .input_tokens
+            .unwrap_or_default()
+            .saturating_sub(cache_read_input_tokens),
         output_tokens: usage.output_tokens.unwrap_or_default(),
         cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
+        cache_read_input_tokens,
+    }
+}
+
+fn response_reasoning_input_item_from_output(
+    reasoning: &ResponseReasoningItem,
+) -> ResponseReasoningInputItem {
+    let encrypted_content = reasoning.encrypted_content.clone();
+
+    let summary = reasoning
+        .summary
+        .iter()
+        .filter_map(|part| match part {
+            crate::responses::ReasoningSummaryPart::SummaryText { text } => {
+                Some(ResponseReasoningSummaryPart::SummaryText { text: text.clone() })
+            }
+            crate::responses::ReasoningSummaryPart::Unknown => None,
+        })
+        .collect();
+
+    ResponseReasoningInputItem {
+        id: reasoning.id.clone(),
+        summary,
+        content: reasoning.content.clone(),
+        encrypted_content,
+        status: reasoning.status.clone(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::responses::{
-        ReasoningSummaryPart, ResponseFunctionToolCall, ResponseOutputItem, ResponseOutputMessage,
-        ResponseReasoningItem, ResponseStatusDetails, ResponseSummary, ResponseUsage,
-        StreamEvent as ResponsesStreamEvent,
+        ReasoningSummaryPart, ResponseError, ResponseFunctionToolCall, ResponseIncompleteDetails,
+        ResponseInputTokensDetails, ResponseOutputItem, ResponseOutputMessage,
+        ResponseReasoningItem, ResponseSummary, ResponseUsage, StreamEvent as ResponsesStreamEvent,
     };
     use futures::{StreamExt, executor::block_on};
     use language_model_core::{
@@ -875,6 +1187,7 @@ mod tests {
             role: Some("assistant".to_string()),
             status: Some("in_progress".to_string()),
             content: vec![],
+            phase: None,
         })
     }
 
@@ -886,6 +1199,21 @@ mod tests {
             call_id: Some("call_123".to_string()),
             arguments: args.map(|s| s.to_string()).unwrap_or_default(),
         })
+    }
+
+    fn response_reasoning_item(
+        id: &str,
+        summary: Vec<ReasoningSummaryPart>,
+        encrypted_content: Option<&str>,
+        status: Option<String>,
+    ) -> ResponseReasoningItem {
+        ResponseReasoningItem {
+            id: Some(id.to_string()),
+            summary,
+            content: Vec::new(),
+            encrypted_content: encrypted_content.map(str::to_string),
+            status,
+        }
     }
 
     #[test]
@@ -906,8 +1234,10 @@ mod tests {
                 response: ResponseSummary {
                     usage: Some(ResponseUsage {
                         input_tokens: Some(5),
+                        input_tokens_details: ResponseInputTokensDetails { cached_tokens: 2 },
                         output_tokens: Some(3),
                         total_tokens: Some(8),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 },
@@ -926,8 +1256,9 @@ mod tests {
         assert!(matches!(
             mapped[2],
             LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
-                input_tokens: 5,
+                input_tokens: 3,
                 output_tokens: 3,
+                cache_read_input_tokens: 2,
                 ..
             })
         ));
@@ -935,6 +1266,34 @@ mod tests {
             mapped[3],
             LanguageModelCompletionEvent::Stop(StopReason::EndTurn)
         ));
+    }
+
+    #[test]
+    fn response_usage_deserializes_cached_tokens() -> Result<()> {
+        let usage: ResponseUsage = serde_json::from_value(json!({
+            "input_tokens": 5,
+            "input_tokens_details": {
+                "cached_tokens": 2,
+            },
+            "output_tokens": 3,
+            "output_tokens_details": {
+                "reasoning_tokens": 1,
+            },
+            "total_tokens": 8,
+        }))?;
+
+        assert_eq!(usage.output_tokens_details.reasoning_tokens, 1);
+        assert_eq!(
+            token_usage_from_response_usage(&usage),
+            TokenUsage {
+                input_tokens: 3,
+                output_tokens: 3,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 2,
+            }
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -1020,6 +1379,7 @@ mod tests {
             true,
             Some(2048),
             Some(ReasoningEffort::Low),
+            false,
         );
 
         let serialized = serde_json::to_value(&response).unwrap();
@@ -1060,6 +1420,8 @@ mod tests {
                     "output": "Sunny"
                 }
             ],
+            "store": false,
+            "include": ["reasoning.encrypted_content"],
             "stream": true,
             "max_output_tokens": 2048,
             "parallel_tool_calls": true,
@@ -1080,7 +1442,176 @@ mod tests {
     }
 
     #[test]
-    fn into_open_ai_response_omits_reasoning_when_thinking_is_disabled() {
+    fn into_open_ai_response_replays_encrypted_reasoning_details() {
+        let tool_call_id = LanguageModelToolUseId::from("call-42");
+        let tool_arguments = "{\"city\":\"Boston\"}".to_string();
+        let tool_use = LanguageModelToolUse {
+            id: tool_call_id,
+            name: Arc::from("get_weather"),
+            raw_input: tool_arguments.clone(),
+            input: json!({ "city": "Boston" }),
+            is_input_complete: true,
+            thought_signature: None,
+        };
+
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::ToolUse(tool_use)],
+                cache: false,
+                reasoning_details: Some(json!({
+                    "reasoning_items": [
+                        {
+                            "id": "rs_123",
+                            "summary": [
+                                {
+                                    "type": "summary_text",
+                                    "text": "Checked what information is needed."
+                                }
+                            ],
+                            "content": [
+                                {
+                                    "type": "reasoning_text",
+                                    "text": "Internal reasoning text."
+                                }
+                            ],
+                            "encrypted_content": "ENC",
+                            "status": "completed",
+                        }
+                    ]
+                })),
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Low),
+            false,
+        );
+
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": "Checked what information is needed."
+                        }
+                    ],
+                    "content": [
+                        {
+                            "type": "reasoning_text",
+                            "text": "Internal reasoning text."
+                        }
+                    ],
+                    "encrypted_content": "ENC",
+                    "status": "completed"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-42",
+                    "name": "get_weather",
+                    "arguments": tool_arguments
+                }
+            ])
+        );
+        assert_eq!(
+            serialized["include"],
+            json!(["reasoning.encrypted_content"])
+        );
+        assert_eq!(serialized.get("reasoning"), None);
+    }
+
+    #[test]
+    fn into_open_ai_response_replays_reasoning_without_encrypted_content() {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("Done.".into())],
+                cache: false,
+                reasoning_details: Some(json!({
+                    "reasoning_items": [
+                        {
+                            "id": "rs_123",
+                            "summary": [],
+                            "status": "completed"
+                        },
+                        {
+                            "id": "rs_456",
+                            "summary": [],
+                            "encrypted_content": "",
+                            "status": "completed"
+                        }
+                    ]
+                })),
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+        };
+
+        let response =
+            into_open_ai_response(request, "custom-model", false, false, None, None, false);
+        let serialized = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [],
+                    "status": "completed"
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_456",
+                    "summary": [],
+                    "encrypted_content": "",
+                    "status": "completed"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Done.",
+                            "annotations": []
+                        }
+                    ]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn into_open_ai_response_omits_reasoning_when_thinking_is_disabled_and_none_is_unsupported() {
         let request = LanguageModelRequest {
             thread_id: None,
             prompt_id: None,
@@ -1107,10 +1638,334 @@ mod tests {
             true,
             None,
             Some(ReasoningEffort::Medium),
+            false,
         );
 
         let serialized = serde_json::to_value(&response).unwrap();
         assert_eq!(serialized.get("reasoning"), None);
+    }
+
+    #[test]
+    fn into_open_ai_response_sends_none_reasoning_when_thinking_is_disabled() -> Result<()> {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".into())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: Some("high".into()),
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5.1",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Medium),
+            true,
+        );
+
+        let serialized = serde_json::to_value(&response)?;
+        assert_eq!(serialized["reasoning"], json!({ "effort": "none" }));
+        assert_eq!(serialized.get("include"), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn into_open_ai_response_uses_default_effort_when_selected_effort_is_none() -> Result<()> {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".into())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: true,
+            thinking_effort: Some("none".into()),
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5.1",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Medium),
+            true,
+        );
+
+        let serialized = serde_json::to_value(&response)?;
+        assert_eq!(
+            serialized["reasoning"],
+            json!({ "effort": "medium", "summary": "auto" })
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn into_open_ai_response_replays_assistant_phase() {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("Done.".into())],
+                cache: false,
+                reasoning_details: Some(json!({
+                    "phase": "final_answer",
+                    "reasoning_items": [
+                        {
+                            "id": "rs_123",
+                            "summary": [],
+                            "encrypted_content": "ENC",
+                            "status": "completed"
+                        }
+                    ]
+                })),
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: true,
+            thinking_effort: None,
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5.3-codex",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Medium),
+            false,
+        );
+
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [],
+                    "encrypted_content": "ENC",
+                    "status": "completed"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "Done.", "annotations": [] }
+                    ],
+                    "phase": "final_answer"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn into_open_ai_response_deduplicates_replayed_reasoning_items() {
+        let first_reasoning_details = json!({
+            "phase": "final_answer",
+            "reasoning_items": [
+                {
+                    "id": "rs_123",
+                    "summary": [],
+                    "encrypted_content": "ENC_OLD",
+                    "status": "in_progress"
+                }
+            ]
+        });
+        let second_reasoning_details = json!({
+            "phase": "final_answer",
+            "reasoning_items": [
+                {
+                    "id": "rs_123",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": "Later metadata has the complete summary."
+                        }
+                    ],
+                    "encrypted_content": "ENC_NEW",
+                    "status": "completed"
+                }
+            ]
+        });
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![
+                LanguageModelRequestMessage {
+                    role: Role::Assistant,
+                    content: vec![MessageContent::Text("First.".into())],
+                    cache: false,
+                    reasoning_details: Some(first_reasoning_details),
+                },
+                LanguageModelRequestMessage {
+                    role: Role::Assistant,
+                    content: vec![MessageContent::Text("Second.".into())],
+                    cache: false,
+                    reasoning_details: Some(second_reasoning_details),
+                },
+            ],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: true,
+            thinking_effort: None,
+            speed: None,
+        };
+
+        let response = into_open_ai_response(
+            request,
+            "gpt-5.3-codex",
+            true,
+            true,
+            None,
+            Some(ReasoningEffort::Medium),
+            false,
+        );
+
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": "Later metadata has the complete summary."
+                        }
+                    ],
+                    "encrypted_content": "ENC_NEW",
+                    "status": "completed"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "First.", "annotations": [] }
+                    ],
+                    "phase": "final_answer"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "Second.", "annotations": [] }
+                    ],
+                    "phase": "final_answer"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn into_open_ai_response_replays_reasoning_details_but_not_thinking_text() {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::Thinking {
+                        text: "This is a reasoning summary, not assistant output.".into(),
+                        signature: None,
+                    },
+                    MessageContent::Text("This is visible assistant output.".into()),
+                ],
+                cache: false,
+                reasoning_details: Some(json!({
+                    "reasoning_items": [
+                        {
+                            "id": "rs_123",
+                            "summary": [
+                                {
+                                    "type": "summary_text",
+                                    "text": "This is the reasoning summary to preserve."
+                                }
+                            ],
+                            "encrypted_content": "ENC",
+                            "status": "completed"
+                        }
+                    ]
+                })),
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+        };
+
+        let response =
+            into_open_ai_response(request, "custom-model", false, false, None, None, false);
+        let serialized = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": "This is the reasoning summary to preserve."
+                        }
+                    ],
+                    "encrypted_content": "ENC",
+                    "status": "completed"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "This is visible assistant output.",
+                            "annotations": []
+                        }
+                    ]
+                }
+            ])
+        );
+        assert_eq!(
+            serialized["include"],
+            json!(["reasoning.encrypted_content"])
+        );
     }
 
     #[test]
@@ -1169,15 +2024,14 @@ mod tests {
     fn responses_stream_uses_max_tokens_stop_reason() {
         let events = vec![ResponsesStreamEvent::Incomplete {
             response: ResponseSummary {
-                status_details: Some(ResponseStatusDetails {
-                    reason: Some("max_output_tokens".into()),
-                    r#type: Some("incomplete".into()),
-                    error: None,
+                incomplete_details: Some(ResponseIncompleteDetails {
+                    reason: Some("max_tokens".into()),
                 }),
                 usage: Some(ResponseUsage {
                     input_tokens: Some(10),
                     output_tokens: Some(20),
                     total_tokens: Some(30),
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1195,6 +2049,128 @@ mod tests {
         assert!(matches!(
             mapped[1],
             LanguageModelCompletionEvent::Stop(StopReason::MaxTokens)
+        ));
+    }
+
+    #[test]
+    fn responses_stream_failed_uses_response_error_message() {
+        let mut mapper = OpenAiResponseEventMapper::new();
+        let mapped = mapper.map_event(ResponsesStreamEvent::Failed {
+            response: ResponseSummary {
+                status: Some("failed".into()),
+                error: Some(ResponseError {
+                    code: Some("server_error".into()),
+                    message: "The model failed to generate a response.".into(),
+                    param: None,
+                }),
+                ..Default::default()
+            },
+        });
+
+        assert_eq!(mapped.len(), 1);
+        let error = mapped.into_iter().next().unwrap().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "server_error: The model failed to generate a response."
+        );
+    }
+
+    #[test]
+    fn responses_stream_deserializes_documented_error_event() {
+        let event = serde_json::from_value::<ResponsesStreamEvent>(json!({
+            "type": "error",
+            "code": "ERR_SOMETHING",
+            "message": "Something went wrong",
+            "param": null,
+            "sequence_number": 1
+        }))
+        .expect("documented error event");
+
+        let mut mapper = OpenAiResponseEventMapper::new();
+        let mapped = mapper.map_event(event);
+
+        assert_eq!(mapped.len(), 1);
+        let error = mapped.into_iter().next().unwrap().unwrap_err();
+        assert_eq!(error.to_string(), "ERR_SOMETHING: Something went wrong");
+    }
+
+    #[test]
+    fn responses_stream_deserializes_response_error_event() {
+        let event = serde_json::from_value::<ResponsesStreamEvent>(json!({
+            "type": "response.error",
+            "error": {
+                "code": "invalid_request_error",
+                "message": "Invalid request."
+            }
+        }))
+        .expect("response error event");
+
+        let mut mapper = OpenAiResponseEventMapper::new();
+        let mapped = mapper.map_event(event);
+
+        assert_eq!(mapped.len(), 1);
+        let error = mapped.into_iter().next().unwrap().unwrap_err();
+        assert_eq!(error.to_string(), "invalid_request_error: Invalid request.");
+    }
+
+    #[test]
+    fn responses_stream_maps_refusal_events_to_refusal_stop() {
+        let delta = serde_json::from_value::<ResponsesStreamEvent>(json!({
+            "type": "response.refusal.delta",
+            "item_id": "msg_123",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "I can't help",
+            "sequence_number": 1
+        }))
+        .expect("documented refusal delta event");
+        let done = serde_json::from_value::<ResponsesStreamEvent>(json!({
+            "type": "response.refusal.done",
+            "item_id": "msg_123",
+            "output_index": 0,
+            "content_index": 0,
+            "refusal": "I can't help with that.",
+            "sequence_number": 2
+        }))
+        .expect("documented refusal done event");
+
+        let mapped = map_response_events(vec![
+            delta,
+            done,
+            ResponsesStreamEvent::Completed {
+                response: ResponseSummary::default(),
+            },
+        ]);
+
+        assert_eq!(mapped.len(), 1);
+        assert!(matches!(
+            mapped[0],
+            LanguageModelCompletionEvent::Stop(StopReason::Refusal)
+        ));
+    }
+
+    #[test]
+    fn responses_stream_maps_refusal_output_to_refusal_stop() {
+        let mapped = map_response_events(vec![ResponsesStreamEvent::Completed {
+            response: ResponseSummary {
+                output: vec![ResponseOutputItem::Message(ResponseOutputMessage {
+                    id: Some("msg_123".into()),
+                    role: Some("assistant".into()),
+                    status: Some("completed".into()),
+                    content: vec![json!({
+                        "type": "refusal",
+                        "refusal": "I can't help with that."
+                    })],
+                    phase: None,
+                })],
+                ..Default::default()
+            },
+        }]);
+
+        assert_eq!(mapped.len(), 1);
+        assert!(matches!(
+            mapped[0],
+            LanguageModelCompletionEvent::Stop(StopReason::Refusal)
         ));
     }
 
@@ -1336,10 +2312,8 @@ mod tests {
             },
             ResponsesStreamEvent::Incomplete {
                 response: ResponseSummary {
-                    status_details: Some(ResponseStatusDetails {
-                        reason: Some("max_output_tokens".into()),
-                        r#type: Some("incomplete".into()),
-                        error: None,
+                    incomplete_details: Some(ResponseIncompleteDetails {
+                        reason: Some("max_tokens".into()),
                     }),
                     output: vec![response_item_function_call(
                         "item_fn",
@@ -1384,10 +2358,8 @@ mod tests {
             },
             ResponsesStreamEvent::Incomplete {
                 response: ResponseSummary {
-                    status_details: Some(ResponseStatusDetails {
-                        reason: Some("max_output_tokens".into()),
-                        r#type: Some("incomplete".into()),
-                        error: None,
+                    incomplete_details: Some(ResponseIncompleteDetails {
+                        reason: Some("max_tokens".into()),
                     }),
                     output: vec![response_item_function_call(
                         "item_fn",
@@ -1525,10 +2497,12 @@ mod tests {
             ResponsesStreamEvent::OutputItemAdded {
                 output_index: 0,
                 sequence_number: None,
-                item: ResponseOutputItem::Reasoning(ResponseReasoningItem {
-                    id: Some("rs_123".into()),
-                    summary: vec![],
-                }),
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    vec![],
+                    None,
+                    None,
+                )),
             },
             ResponsesStreamEvent::ReasoningSummaryPartAdded {
                 item_id: "rs_123".into(),
@@ -1578,9 +2552,9 @@ mod tests {
             ResponsesStreamEvent::OutputItemDone {
                 output_index: 0,
                 sequence_number: None,
-                item: ResponseOutputItem::Reasoning(ResponseReasoningItem {
-                    id: Some("rs_123".into()),
-                    summary: vec![
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    vec![
                         ReasoningSummaryPart::SummaryText {
                             text: "Thinking about the answer".into(),
                         },
@@ -1588,7 +2562,9 @@ mod tests {
                             text: "Second part".into(),
                         },
                     ],
-                }),
+                    None,
+                    None,
+                )),
             },
             ResponsesStreamEvent::OutputItemAdded {
                 output_index: 1,
@@ -1643,20 +2619,24 @@ mod tests {
             ResponsesStreamEvent::OutputItemAdded {
                 output_index: 0,
                 sequence_number: None,
-                item: ResponseOutputItem::Reasoning(ResponseReasoningItem {
-                    id: Some("rs_789".into()),
-                    summary: vec![],
-                }),
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_789",
+                    vec![],
+                    None,
+                    None,
+                )),
             },
             ResponsesStreamEvent::OutputItemDone {
                 output_index: 0,
                 sequence_number: None,
-                item: ResponseOutputItem::Reasoning(ResponseReasoningItem {
-                    id: Some("rs_789".into()),
-                    summary: vec![ReasoningSummaryPart::SummaryText {
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_789",
+                    vec![ReasoningSummaryPart::SummaryText {
                         text: "Summary without deltas".into(),
                     }],
-                }),
+                    None,
+                    None,
+                )),
             },
             ResponsesStreamEvent::Completed {
                 response: ResponseSummary::default(),
@@ -1669,6 +2649,252 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, LanguageModelCompletionEvent::Thinking { .. })),
             "OutputItemDone reasoning should not produce Thinking events"
+        );
+    }
+
+    #[test]
+    fn responses_stream_preserves_encrypted_reasoning_details() {
+        let mut reasoning_item = response_reasoning_item(
+            "rs_123",
+            vec![ReasoningSummaryPart::SummaryText {
+                text: "Checked what information is needed.".into(),
+            }],
+            Some("ENC"),
+            Some("completed".into()),
+        );
+        reasoning_item.content = vec![json!({
+            "type": "reasoning_text",
+            "text": "Internal reasoning text."
+        })];
+
+        let events = vec![
+            ResponsesStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: ResponseOutputItem::Reasoning(reasoning_item),
+            },
+            ResponsesStreamEvent::Completed {
+                response: ResponseSummary::default(),
+            },
+        ];
+
+        let mapped = map_response_events(events);
+        let details = mapped
+            .iter()
+            .find_map(|event| match event {
+                LanguageModelCompletionEvent::ReasoningDetails(details) => Some(details),
+                _ => None,
+            })
+            .expect("reasoning details");
+
+        assert_eq!(
+            details,
+            &json!({
+                "reasoning_items": [
+                    {
+                        "id": "rs_123",
+                        "summary": [
+                            {
+                                "type": "summary_text",
+                                "text": "Checked what information is needed."
+                            }
+                        ],
+                        "content": [
+                            {
+                                "type": "reasoning_text",
+                                "text": "Internal reasoning text."
+                            }
+                        ],
+                        "encrypted_content": "ENC",
+                        "status": "completed",
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn responses_stream_replaces_reasoning_details_with_same_id() {
+        let events = vec![
+            ResponsesStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    Vec::new(),
+                    Some("ENC_OLD"),
+                    Some("in_progress".into()),
+                )),
+            },
+            ResponsesStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    vec![ReasoningSummaryPart::SummaryText {
+                        text: "Finished reasoning.".into(),
+                    }],
+                    Some("ENC_NEW"),
+                    Some("completed".into()),
+                )),
+            },
+            ResponsesStreamEvent::Completed {
+                response: ResponseSummary::default(),
+            },
+        ];
+
+        let mapped = map_response_events(events);
+        let details = mapped
+            .iter()
+            .filter_map(|event| match event {
+                LanguageModelCompletionEvent::ReasoningDetails(details) => Some(details),
+                _ => None,
+            })
+            .next_back()
+            .expect("reasoning details");
+
+        assert_eq!(
+            details,
+            &json!({
+                "reasoning_items": [
+                    {
+                        "id": "rs_123",
+                        "summary": [
+                            {
+                                "type": "summary_text",
+                                "text": "Finished reasoning."
+                            }
+                        ],
+                        "encrypted_content": "ENC_NEW",
+                        "status": "completed"
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn responses_stream_reemits_reasoning_details_after_phase_less_message_start() {
+        let events = vec![
+            ResponsesStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    Vec::new(),
+                    Some("ENC"),
+                    Some("completed".into()),
+                )),
+            },
+            ResponsesStreamEvent::OutputItemAdded {
+                output_index: 1,
+                sequence_number: None,
+                item: ResponseOutputItem::Message(ResponseOutputMessage {
+                    id: Some("msg_123".into()),
+                    role: Some("assistant".into()),
+                    status: Some("in_progress".into()),
+                    content: vec![],
+                    phase: None,
+                }),
+            },
+            ResponsesStreamEvent::OutputTextDelta {
+                item_id: "msg_123".into(),
+                output_index: 1,
+                content_index: Some(0),
+                delta: "Hello".into(),
+            },
+            ResponsesStreamEvent::Completed {
+                response: ResponseSummary::default(),
+            },
+        ];
+
+        let mapped = map_response_events(events);
+        let start_message_index = mapped
+            .iter()
+            .position(|event| matches!(event, LanguageModelCompletionEvent::StartMessage { .. }))
+            .expect("start message");
+        let details = mapped
+            .iter()
+            .skip(start_message_index + 1)
+            .find_map(|event| match event {
+                LanguageModelCompletionEvent::ReasoningDetails(details) => Some(details),
+                _ => None,
+            })
+            .expect("reasoning details after start message");
+
+        assert_eq!(
+            details,
+            &json!({
+                "reasoning_items": [
+                    {
+                        "id": "rs_123",
+                        "summary": [],
+                        "encrypted_content": "ENC",
+                        "status": "completed"
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn responses_stream_preserves_assistant_phase_with_reasoning_details() {
+        let events = vec![
+            ResponsesStreamEvent::OutputItemAdded {
+                output_index: 0,
+                sequence_number: None,
+                item: ResponseOutputItem::Message(ResponseOutputMessage {
+                    id: Some("msg_123".into()),
+                    role: Some("assistant".into()),
+                    status: Some("in_progress".into()),
+                    content: vec![],
+                    phase: Some("commentary".into()),
+                }),
+            },
+            ResponsesStreamEvent::OutputTextDelta {
+                item_id: "msg_123".into(),
+                output_index: 0,
+                content_index: Some(0),
+                delta: "I will inspect the workspace.".into(),
+            },
+            ResponsesStreamEvent::OutputItemDone {
+                output_index: 1,
+                sequence_number: None,
+                item: ResponseOutputItem::Reasoning(response_reasoning_item(
+                    "rs_123",
+                    Vec::new(),
+                    Some("ENC"),
+                    Some("completed".into()),
+                )),
+            },
+            ResponsesStreamEvent::Completed {
+                response: ResponseSummary::default(),
+            },
+        ];
+
+        let mapped = map_response_events(events);
+        let details = mapped
+            .iter()
+            .filter_map(|event| match event {
+                LanguageModelCompletionEvent::ReasoningDetails(details) => Some(details),
+                _ => None,
+            })
+            .next_back()
+            .expect("reasoning details");
+
+        assert_eq!(
+            details,
+            &json!({
+                "phase": "commentary",
+                "reasoning_items": [
+                    {
+                        "id": "rs_123",
+                        "summary": [],
+                        "encrypted_content": "ENC",
+                        "status": "completed"
+                    }
+                ]
+            })
         );
     }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -58,26 +58,14 @@ impl From<Role> for String {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
-    #[serde(rename = "gpt-3.5-turbo")]
-    ThreePointFiveTurbo,
     #[serde(rename = "gpt-4")]
     Four,
-    #[serde(rename = "gpt-4-turbo")]
-    FourTurbo,
     #[serde(rename = "gpt-4o-mini")]
     FourOmniMini,
-    #[serde(rename = "gpt-4.1-nano")]
-    FourPointOneNano,
-    #[serde(rename = "o1")]
-    O1,
-    #[serde(rename = "o3-mini")]
-    O3Mini,
     #[serde(rename = "o3")]
     O3,
     #[serde(rename = "gpt-5")]
     Five,
-    #[serde(rename = "gpt-5-codex")]
-    FiveCodex,
     #[serde(rename = "gpt-5-mini")]
     #[default]
     FiveMini,
@@ -87,10 +75,12 @@ pub enum Model {
     FivePointOne,
     #[serde(rename = "gpt-5.2")]
     FivePointTwo,
-    #[serde(rename = "gpt-5.2-codex")]
-    FivePointTwoCodex,
     #[serde(rename = "gpt-5.3-codex")]
     FivePointThreeCodex,
+    #[serde(rename = "gpt-5.4-nano")]
+    FivePointFourNano,
+    #[serde(rename = "gpt-5.4-mini")]
+    FivePointFourMini,
     #[serde(rename = "gpt-5.4")]
     FivePointFour,
     #[serde(rename = "gpt-5.4-pro")]
@@ -130,22 +120,17 @@ impl Model {
 
     pub fn from_id(id: &str) -> Result<Self> {
         match id {
-            "gpt-3.5-turbo" => Ok(Self::ThreePointFiveTurbo),
             "gpt-4" => Ok(Self::Four),
-            "gpt-4-turbo-preview" => Ok(Self::FourTurbo),
             "gpt-4o-mini" => Ok(Self::FourOmniMini),
-            "gpt-4.1-nano" => Ok(Self::FourPointOneNano),
-            "o1" => Ok(Self::O1),
-            "o3-mini" => Ok(Self::O3Mini),
             "o3" => Ok(Self::O3),
             "gpt-5" => Ok(Self::Five),
-            "gpt-5-codex" => Ok(Self::FiveCodex),
             "gpt-5-mini" => Ok(Self::FiveMini),
             "gpt-5-nano" => Ok(Self::FiveNano),
             "gpt-5.1" => Ok(Self::FivePointOne),
             "gpt-5.2" => Ok(Self::FivePointTwo),
-            "gpt-5.2-codex" => Ok(Self::FivePointTwoCodex),
             "gpt-5.3-codex" => Ok(Self::FivePointThreeCodex),
+            "gpt-5.4-nano" => Ok(Self::FivePointFourNano),
+            "gpt-5.4-mini" => Ok(Self::FivePointFourMini),
             "gpt-5.4" => Ok(Self::FivePointFour),
             "gpt-5.4-pro" => Ok(Self::FivePointFourPro),
             "gpt-5.5" => Ok(Self::FivePointFive),
@@ -156,22 +141,17 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
             Self::Four => "gpt-4",
-            Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmniMini => "gpt-4o-mini",
-            Self::FourPointOneNano => "gpt-4.1-nano",
-            Self::O1 => "o1",
-            Self::O3Mini => "o3-mini",
             Self::O3 => "o3",
             Self::Five => "gpt-5",
-            Self::FiveCodex => "gpt-5-codex",
             Self::FiveMini => "gpt-5-mini",
             Self::FiveNano => "gpt-5-nano",
             Self::FivePointOne => "gpt-5.1",
             Self::FivePointTwo => "gpt-5.2",
-            Self::FivePointTwoCodex => "gpt-5.2-codex",
             Self::FivePointThreeCodex => "gpt-5.3-codex",
+            Self::FivePointFourNano => "gpt-5.4-nano",
+            Self::FivePointFourMini => "gpt-5.4-mini",
             Self::FivePointFour => "gpt-5.4",
             Self::FivePointFourPro => "gpt-5.4-pro",
             Self::FivePointFive => "gpt-5.5",
@@ -182,22 +162,17 @@ impl Model {
 
     pub fn display_name(&self) -> &str {
         match self {
-            Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
             Self::Four => "gpt-4",
-            Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmniMini => "gpt-4o-mini",
-            Self::FourPointOneNano => "gpt-4.1-nano",
-            Self::O1 => "o1",
-            Self::O3Mini => "o3-mini",
             Self::O3 => "o3",
             Self::Five => "gpt-5",
-            Self::FiveCodex => "gpt-5-codex",
             Self::FiveMini => "gpt-5-mini",
             Self::FiveNano => "gpt-5-nano",
             Self::FivePointOne => "gpt-5.1",
             Self::FivePointTwo => "gpt-5.2",
-            Self::FivePointTwoCodex => "gpt-5.2-codex",
             Self::FivePointThreeCodex => "gpt-5.3-codex",
+            Self::FivePointFourNano => "gpt-5.4-nano",
+            Self::FivePointFourMini => "gpt-5.4-mini",
             Self::FivePointFour => "gpt-5.4",
             Self::FivePointFourPro => "gpt-5.4-pro",
             Self::FivePointFive => "gpt-5.5",
@@ -208,22 +183,17 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::ThreePointFiveTurbo => 16_385,
             Self::Four => 8_192,
-            Self::FourTurbo => 128_000,
             Self::FourOmniMini => 128_000,
-            Self::FourPointOneNano => 1_047_576,
-            Self::O1 => 200_000,
-            Self::O3Mini => 200_000,
             Self::O3 => 200_000,
             Self::Five => 272_000,
-            Self::FiveCodex => 272_000,
             Self::FiveMini => 400_000,
             Self::FiveNano => 400_000,
             Self::FivePointOne => 400_000,
             Self::FivePointTwo => 400_000,
-            Self::FivePointTwoCodex => 400_000,
             Self::FivePointThreeCodex => 400_000,
+            Self::FivePointFourNano => 400_000,
+            Self::FivePointFourMini => 400_000,
             Self::FivePointFour => 1_050_000,
             Self::FivePointFourPro => 1_050_000,
             Self::FivePointFive => 1_050_000,
@@ -237,22 +207,17 @@ impl Model {
             Self::Custom {
                 max_output_tokens, ..
             } => *max_output_tokens,
-            Self::ThreePointFiveTurbo => Some(4_096),
             Self::Four => Some(8_192),
-            Self::FourTurbo => Some(4_096),
             Self::FourOmniMini => Some(16_384),
-            Self::FourPointOneNano => Some(32_768),
-            Self::O1 => Some(100_000),
-            Self::O3Mini => Some(100_000),
             Self::O3 => Some(100_000),
             Self::Five => Some(128_000),
-            Self::FiveCodex => Some(128_000),
             Self::FiveMini => Some(128_000),
             Self::FiveNano => Some(128_000),
             Self::FivePointOne => Some(128_000),
             Self::FivePointTwo => Some(128_000),
-            Self::FivePointTwoCodex => Some(128_000),
             Self::FivePointThreeCodex => Some(128_000),
+            Self::FivePointFourNano => Some(128_000),
+            Self::FivePointFourMini => Some(128_000),
             Self::FivePointFour => Some(128_000),
             Self::FivePointFourPro => Some(128_000),
             Self::FivePointFive => Some(128_000),
@@ -265,18 +230,16 @@ impl Model {
             Self::Custom {
                 reasoning_effort, ..
             } => reasoning_effort.to_owned(),
-            Self::O1
-            | Self::O3
-            | Self::O3Mini
+            Self::FivePointOne
+            | Self::FivePointTwo
+            | Self::FivePointFour
+            | Self::FivePointFourMini
+            | Self::FivePointFourNano => Some(ReasoningEffort::None),
+            Self::O3
             | Self::Five
-            | Self::FiveCodex
             | Self::FiveMini
             | Self::FiveNano
-            | Self::FivePointOne
-            | Self::FivePointTwo
-            | Self::FivePointTwoCodex
             | Self::FivePointThreeCodex
-            | Self::FivePointFour
             | Self::FivePointFourPro
             | Self::FivePointFive
             | Self::FivePointFivePro => Some(ReasoningEffort::Medium),
@@ -290,13 +253,20 @@ impl Model {
                 reasoning_effort: Some(effort),
                 ..
             } => match effort {
+                ReasoningEffort::None => &[ReasoningEffort::None],
                 ReasoningEffort::Minimal => &[ReasoningEffort::Minimal],
                 ReasoningEffort::Low => &[ReasoningEffort::Low],
                 ReasoningEffort::Medium => &[ReasoningEffort::Medium],
                 ReasoningEffort::High => &[ReasoningEffort::High],
                 ReasoningEffort::XHigh => &[ReasoningEffort::XHigh],
             },
-            Self::O1 | Self::O3 | Self::O3Mini | Self::FivePointOne => &[
+            Self::O3 => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+            Self::FivePointOne => &[
+                ReasoningEffort::None,
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,
@@ -307,10 +277,13 @@ impl Model {
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,
             ],
-            Self::FiveCodex
-            | Self::FivePointTwoCodex
-            | Self::FivePointThreeCodex
-            | Self::FivePointFourPro => &[
+            Self::FivePointFourPro | Self::FivePointFivePro => &[
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+            Self::FivePointThreeCodex => &[
+                ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,
                 ReasoningEffort::XHigh,
@@ -318,7 +291,9 @@ impl Model {
             Self::FivePointTwo
             | Self::FivePointFour
             | Self::FivePointFive
-            | Self::FivePointFivePro => &[
+            | Self::FivePointFourMini
+            | Self::FivePointFourNano => &[
+                ReasoningEffort::None,
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,
@@ -343,24 +318,21 @@ impl Model {
     /// If the model does not support the parameter, do not pass it up, or the API will return an error.
     pub fn supports_parallel_tool_calls(&self) -> bool {
         match self {
-            Self::ThreePointFiveTurbo
-            | Self::Four
-            | Self::FourTurbo
+            Self::Four
             | Self::FourOmniMini
-            | Self::FourPointOneNano
             | Self::Five
-            | Self::FiveCodex
             | Self::FiveMini
             | Self::FivePointOne
             | Self::FivePointTwo
-            | Self::FivePointTwoCodex
             | Self::FivePointThreeCodex
             | Self::FivePointFour
+            | Self::FivePointFourMini
+            | Self::FivePointFourNano
             | Self::FivePointFourPro
             | Self::FivePointFive
             | Self::FivePointFivePro
             | Self::FiveNano => true,
-            Self::O1 | Self::O3 | Self::O3Mini | Model::Custom { .. } => false,
+            Self::O3 | Model::Custom { .. } => false,
         }
     }
 
@@ -369,6 +341,81 @@ impl Model {
     /// If the model does not support the parameter, do not pass it up.
     pub fn supports_prompt_cache_key(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Model, ReasoningEffort};
+
+    #[test]
+    fn gpt_5_1_uses_none_reasoning_by_default() {
+        let expected_efforts = [
+            ReasoningEffort::None,
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+        ];
+
+        assert_eq!(
+            Model::FivePointOne.reasoning_effort(),
+            Some(ReasoningEffort::None)
+        );
+        assert_eq!(
+            Model::FivePointOne.supported_reasoning_efforts(),
+            expected_efforts.as_slice()
+        );
+    }
+
+    #[test]
+    fn newer_frontier_models_support_none_reasoning() {
+        let expected_efforts = [
+            ReasoningEffort::None,
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ];
+
+        assert_eq!(
+            Model::FivePointTwo.reasoning_effort(),
+            Some(ReasoningEffort::None)
+        );
+        assert_eq!(
+            Model::FivePointTwo.supported_reasoning_efforts(),
+            expected_efforts.as_slice()
+        );
+        assert_eq!(
+            Model::FivePointFour.reasoning_effort(),
+            Some(ReasoningEffort::None)
+        );
+        assert_eq!(
+            Model::FivePointFour.supported_reasoning_efforts(),
+            expected_efforts.as_slice()
+        );
+        assert_eq!(
+            Model::FivePointFive.reasoning_effort(),
+            Some(ReasoningEffort::Medium)
+        );
+        assert_eq!(
+            Model::FivePointFive.supported_reasoning_efforts(),
+            expected_efforts.as_slice()
+        );
+    }
+
+    #[test]
+    fn newer_codex_models_support_low_reasoning_effort() {
+        let expected_efforts = [
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ];
+
+        assert_eq!(
+            Model::FivePointThreeCodex.supported_reasoning_efforts(),
+            expected_efforts.as_slice()
+        );
     }
 }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -265,10 +265,66 @@ impl Model {
             Self::Custom {
                 reasoning_effort, ..
             } => reasoning_effort.to_owned(),
-            Self::FivePointThreeCodex | Self::FivePointFourPro | Self::FivePointFivePro => {
-                Some(ReasoningEffort::Medium)
-            }
+            Self::O1
+            | Self::O3
+            | Self::O3Mini
+            | Self::Five
+            | Self::FiveCodex
+            | Self::FiveMini
+            | Self::FiveNano
+            | Self::FivePointOne
+            | Self::FivePointTwo
+            | Self::FivePointTwoCodex
+            | Self::FivePointThreeCodex
+            | Self::FivePointFour
+            | Self::FivePointFourPro
+            | Self::FivePointFive
+            | Self::FivePointFivePro => Some(ReasoningEffort::Medium),
             _ => None,
+        }
+    }
+
+    pub fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
+        match self {
+            Self::Custom {
+                reasoning_effort: Some(effort),
+                ..
+            } => match effort {
+                ReasoningEffort::Minimal => &[ReasoningEffort::Minimal],
+                ReasoningEffort::Low => &[ReasoningEffort::Low],
+                ReasoningEffort::Medium => &[ReasoningEffort::Medium],
+                ReasoningEffort::High => &[ReasoningEffort::High],
+                ReasoningEffort::XHigh => &[ReasoningEffort::XHigh],
+            },
+            Self::O1 | Self::O3 | Self::O3Mini | Self::FivePointOne => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+            Self::Five | Self::FiveMini | Self::FiveNano => &[
+                ReasoningEffort::Minimal,
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+            Self::FiveCodex
+            | Self::FivePointTwoCodex
+            | Self::FivePointThreeCodex
+            | Self::FivePointFourPro => &[
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+            Self::FivePointTwo
+            | Self::FivePointFour
+            | Self::FivePointFive
+            | Self::FivePointFivePro => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+            _ => &[],
         }
     }
 

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -11,6 +11,9 @@ pub struct Request {
     pub model: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub input: Vec<ResponseInputItem>,
+    pub store: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<ResponseIncludable>,
     #[serde(default)]
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -31,18 +34,28 @@ pub struct Request {
     pub reasoning: Option<ReasoningConfig>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseIncludable {
+    #[serde(rename = "reasoning.encrypted_content")]
+    ReasoningEncryptedContent,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponseInputItem {
     Message(ResponseMessageItem),
     FunctionCall(ResponseFunctionCallItem),
     FunctionCallOutput(ResponseFunctionCallOutputItem),
+    Reasoning(ResponseReasoningInputItem),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponseMessageItem {
     pub role: Role,
     pub content: Vec<ResponseInputContent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -56,6 +69,26 @@ pub struct ResponseFunctionCallItem {
 pub struct ResponseFunctionCallOutputItem {
     pub call_id: String,
     pub output: ResponseFunctionCallOutputContent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResponseReasoningInputItem {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub summary: Vec<ResponseReasoningSummaryPart>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResponseReasoningSummaryPart {
+    SummaryText { text: String },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -111,9 +144,13 @@ pub enum ToolDefinition {
     },
 }
 
-#[derive(Deserialize, Debug)]
-pub struct Error {
+#[derive(Deserialize, Debug, Clone)]
+pub struct ResponseError {
+    #[serde(default)]
+    pub code: Option<String>,
     pub message: String,
+    #[serde(default)]
+    pub param: Option<Value>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -167,6 +204,24 @@ pub enum StreamEvent {
         content_index: Option<usize>,
         text: String,
     },
+    #[serde(rename = "response.refusal.delta")]
+    RefusalDelta {
+        item_id: String,
+        output_index: usize,
+        content_index: usize,
+        delta: String,
+        #[serde(default)]
+        sequence_number: Option<u64>,
+    },
+    #[serde(rename = "response.refusal.done")]
+    RefusalDone {
+        item_id: String,
+        output_index: usize,
+        content_index: usize,
+        refusal: String,
+        #[serde(default)]
+        sequence_number: Option<u64>,
+    },
     #[serde(rename = "response.reasoning_summary_part.added")]
     ReasoningSummaryPartAdded {
         item_id: String,
@@ -214,9 +269,12 @@ pub enum StreamEvent {
     #[serde(rename = "response.failed")]
     Failed { response: ResponseSummary },
     #[serde(rename = "response.error")]
-    Error { error: Error },
+    Error { error: ResponseError },
     #[serde(rename = "error")]
-    GenericError { error: Error },
+    GenericError {
+        #[serde(flatten)]
+        error: ResponseError,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -228,7 +286,9 @@ pub struct ResponseSummary {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
-    pub status_details: Option<ResponseStatusDetails>,
+    pub incomplete_details: Option<ResponseIncompleteDetails>,
+    #[serde(default)]
+    pub error: Option<ResponseError>,
     #[serde(default)]
     pub usage: Option<ResponseUsage>,
     #[serde(default)]
@@ -236,13 +296,9 @@ pub struct ResponseSummary {
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
-pub struct ResponseStatusDetails {
+pub struct ResponseIncompleteDetails {
     #[serde(default)]
     pub reason: Option<String>,
-    #[serde(default)]
-    pub r#type: Option<String>,
-    #[serde(default)]
-    pub error: Option<Value>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -250,9 +306,25 @@ pub struct ResponseUsage {
     #[serde(default)]
     pub input_tokens: Option<u64>,
     #[serde(default)]
+    pub input_tokens_details: ResponseInputTokensDetails,
+    #[serde(default)]
     pub output_tokens: Option<u64>,
     #[serde(default)]
+    pub output_tokens_details: ResponseOutputTokensDetails,
+    #[serde(default)]
     pub total_tokens: Option<u64>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+pub struct ResponseInputTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u64,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+pub struct ResponseOutputTokensDetails {
+    #[serde(default)]
+    pub reasoning_tokens: u64,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -271,6 +343,12 @@ pub struct ResponseReasoningItem {
     pub id: Option<String>,
     #[serde(default)]
     pub summary: Vec<ReasoningSummaryPart>,
+    #[serde(default)]
+    pub content: Vec<Value>,
+    #[serde(default)]
+    pub encrypted_content: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -293,6 +371,8 @@ pub struct ResponseOutputMessage {
     pub role: Option<String>,
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub phase: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -441,8 +521,17 @@ pub async fn stream_response(
                         });
                     }
 
-                    all_events.push(StreamEvent::Completed {
-                        response: response_summary,
+                    let status = response_summary.status.clone();
+                    all_events.push(match status.as_deref() {
+                        Some("incomplete") => StreamEvent::Incomplete {
+                            response: response_summary,
+                        },
+                        Some("failed") => StreamEvent::Failed {
+                            response: response_summary,
+                        },
+                        _ => StreamEvent::Completed {
+                            response: response_summary,
+                        },
                     });
 
                     Ok(futures::stream::iter(all_events.into_iter().map(Ok)).boxed())

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -9,9 +9,10 @@ use crate::{ReasoningEffort, RequestError, Role, ToolChoice};
 #[derive(Serialize, Debug)]
 pub struct Request {
     pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub input: Vec<ResponseInputItem>,
-    pub store: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<ResponseIncludable>,
     #[serde(default)]
@@ -32,6 +33,8 @@ pub struct Request {
     pub prompt_cache_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -395,13 +398,17 @@ pub async fn stream_response(
     api_url: &str,
     api_key: &str,
     request: Request,
+    extra_headers: Vec<(String, String)>,
 ) -> Result<BoxStream<'static, Result<StreamEvent>>, RequestError> {
     let uri = format!("{api_url}/responses");
-    let request_builder = HttpRequest::builder()
+    let mut request_builder = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
         .header("Content-Type", "application/json")
         .header("Authorization", format!("Bearer {}", api_key.trim()));
+    for (name, value) in &extra_headers {
+        request_builder = request_builder.header(name.as_str(), value.as_str());
+    }
 
     let is_streaming = request.stream;
     let request = request_builder

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -1063,9 +1063,8 @@ impl ContextServerStore {
         // Start a loopback HTTP server on an ephemeral port. The redirect URI
         // includes this port so the browser sends the callback directly to our
         // process.
-        let (redirect_uri, callback_rx) = oauth::start_callback_server()
-            .await
-            .context("Failed to start OAuth callback server")?;
+        let (redirect_uri, callback_rx) =
+            oauth::start_callback_server().context("Failed to start OAuth callback server")?;
 
         let http_client = cx.update(|cx| cx.http_client());
         let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
@@ -1093,9 +1092,6 @@ impl ContextServerStore {
 
         let callback = callback_rx
             .await
-            .map_err(|_| {
-                anyhow::anyhow!("OAuth callback server was shut down before receiving a response")
-            })?
             .context("OAuth callback server received an invalid request")?;
 
         if callback.state != state_param {

--- a/crates/project/src/lsp_store/vue_language_server_ext.rs
+++ b/crates/project/src/lsp_store/vue_language_server_ext.rs
@@ -99,8 +99,8 @@ pub fn register_requests(lsp_store: WeakEntity<LspStore>, language_server: &Lang
                             util::ConnectionResult::Result(Ok(result)) => match result {
                                 Some(Value::Object(mut map)) => map
                                     .remove("body")
-                                    .unwrap_or(Value::Object(map)),
-                                Some(other) => other,
+                                    .unwrap_or(Value::Null),
+                                Some(_) => Value::Null,
                                 None => Value::Null,
                             },
                             util::ConnectionResult::Result(Err(error)) => {

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.2.3"
+version = "1.2.4"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.2.5"
+version = "1.2.6"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.2.4"
+version = "1.2.5"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]

--- a/tooling/xtask/src/tasks/compliance.rs
+++ b/tooling/xtask/src/tasks/compliance.rs
@@ -19,7 +19,7 @@ pub(crate) struct ComplianceArgs {
 }
 
 const IGNORE_LIST: &[&str] = &[
-    "75fa566511e3ae7d03cfd76008512080291bd81d", // GitHub nuked this PR out of orbit
+    "0ed077852ca4b04fbdc5d3781a85a491da5f011b", // Zed Zippy version bump that raced with another PR in the queue
 ];
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## Summary

- Cherry-picks all upstream Zed commits from `v1.2.3` through `v1.2.6` onto `stable/v1.2`.
- Leaves this branch as an upstream mirror with no NeoZed-specific edits.

## Verification

- Confirmed `codex/review-upstream-v1.2.6-stable` has no diff from `upstream/v1.2.x` after applying the range.

Release Notes:

- N/A